### PR TITLE
feat: strict subcommands and native certs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,15 +331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -647,16 +642,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1225,16 +1210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1330,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-ext"
@@ -1866,6 +1847,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,10 +1910,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2017,12 +2052,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -2443,11 +2472,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
- "flate2",
  "log",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots 0.26.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 terminal_size = "0.4"
 
 # HTTP (for pricing data fetch)
-ureq = "2"
+ureq = { version = "2", default-features = false, features = ["tls", "native-certs", "json"] }
 
 # TUI (tokemon top)
 ratatui = { version = "0.30", features = ["crossterm"] }

--- a/README.md
+++ b/README.md
@@ -13,19 +13,9 @@
 
 ---
 
-Unified token usage tracking across all your AI coding tools. tokemon reads local session logs from 16 providers, estimates costs via LiteLLM pricing, and presents daily, weekly, or monthly reports in the terminal or as JSON.
+Unified token usage tracking across all your AI coding tools. `tokemon top` provides a live, continuously updating dashboard of your token usage and costs across 16 different providers. It reads local session logs, estimates costs via LiteLLM pricing, and presents beautiful TUI monitoring, static reports, or raw JSON.
 
-```
-╭────────────┬─────────┬─────────┬─────────────┬───────────────┬───────────────┬──────────╮
-│ Date       │   Input │  Output │ Cache Write │    Cache Read │  Total Tokens │     Cost │
-├────────────┼─────────┼─────────┼─────────────┼───────────────┼───────────────┼──────────┤
-│ 2026-02-20 │ 363,489 │ 151,776 │  25,842,224 │   391,480,542 │   417,838,031 │  $485.59 │
-│ 2026-02-21 │ 305,260 │ 266,882 │  25,424,702 │   551,464,876 │   577,461,720 │  $733.72 │
-│ 2026-02-22 │ 317,451 │ 218,759 │  40,516,730 │   644,994,151 │   686,047,091 │  $877.50 │
-│ ...        │         │         │             │               │               │          │
-│ TOTAL      │ 986,200 │ 637,417 │  91,783,656 │ 1,587,939,569 │ 1,681,346,842 │ $2096.81 │
-╰────────────┴─────────┴─────────┴─────────────┴───────────────┴───────────────┴──────────╯
-```
+![tokemon dashboard](assets/dashboard.png)
 
 ## Highlights
 
@@ -83,18 +73,21 @@ cargo install --path .
 ## Quick Start
 
 ```bash
+# Launch the live monitoring dashboard (default view: today)
+tokemon top
+
 # See which providers are installed
 tokemon discover
 
-# Daily usage report (default)
-tokemon
+# Daily static usage report
+tokemon report
 
 # Per-model breakdown view
-tokemon -d breakdown
+tokemon report -d breakdown
 
 # Weekly or monthly report
-tokemon -f weekly
-tokemon -f monthly --json
+tokemon report -f weekly
+tokemon report -f monthly --json
 
 # Budget overview
 tokemon budget
@@ -113,9 +106,11 @@ tokemon statusline -f weekly
 ## Usage
 
 ```
-tokemon [OPTIONS] [COMMAND]
+tokemon [OPTIONS] <COMMAND>
 
 Commands:
+  top          Live monitoring dashboard
+  report       Generate a static usage report (table, json, or csv)
   statusline   Compact one-line output for shell prompts and status bars
   budget       Show spending vs configured limits
   sessions     Show per-session cost breakdown

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub enum SortOrder {
 )]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Option<Commands>,
+    pub command: Commands,
 
     /// Aggregation frequency: daily, weekly, or monthly
     #[arg(short = 'f', long, global = true, value_enum, default_value = "daily")]
@@ -110,6 +110,8 @@ pub enum Frequency {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Generate a static usage report (table, json, or csv)
+    Report,
     /// Compact one-line output for shell prompts and status bars
     Statusline,
     /// Show budget progress against configured limits

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,19 +43,19 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let config = Config::load();
 
-    match cli.command.as_ref() {
-        None => cmd_report(&cli, &config),
-        Some(Commands::Discover) => {
+    match &cli.command {
+        Commands::Report => cmd_report(&cli, &config),
+        Commands::Discover => {
             cmd_discover();
             Ok(())
         }
-        Some(Commands::Init) => cmd_init(),
-        Some(Commands::Statusline) => cmd_statusline(&cli, &config),
-        Some(Commands::Budget) => cmd_budget(&cli, &config),
-        Some(Commands::Sessions { top }) => cmd_sessions(&cli, &config, *top),
-        Some(Commands::Prune { before }) => cmd_prune(*before),
-        Some(Commands::Mcp) => mcp::run(&cli, &config),
-        Some(Commands::Top { view, interval }) => {
+        Commands::Init => cmd_init(),
+        Commands::Statusline => cmd_statusline(&cli, &config),
+        Commands::Budget => cmd_budget(&cli, &config),
+        Commands::Sessions { top } => cmd_sessions(&cli, &config, *top),
+        Commands::Prune { before } => cmd_prune(*before),
+        Commands::Mcp => mcp::run(&cli, &config),
+        Commands::Top { view, interval } => {
             // CLI --interval overrides config, config overrides hardcoded default
             let tick = if *interval > 0 {
                 *interval


### PR DESCRIPTION
## Summary
This PR transitions tokemon to a Strict Toolbelt paradigm and ensures corporate TLS compatibility.

- Moves to a strict subcommand pattern (e.g. `tokemon report`) to better surface the diverse toolset.
- Promotes the TUI dashboard to the flagship feature in the README.
- Upgrades `ureq` to use the `native-certs` feature to allow corporate firewall/proxy SSL decryption interceptors to successfully resolve without throwing 'UnknownIssuer' errors.