### PR TITLE
chore: desloppify queue fixes and error propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,23 +360,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "futures-core",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -385,9 +368,10 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1126,12 +1110,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1646,7 +1624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core",
 ]
@@ -1807,19 +1785,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1827,7 +1792,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2177,18 +2142,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
-dependencies = [
- "rustix 1.1.4",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2332,7 +2287,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "crossterm 0.28.1",
+ "crossterm",
  "directories",
  "futures-lite",
  "notify",
@@ -2343,7 +2298,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tabled",
- "terminal_size",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -2874,24 +2828,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2923,28 +2859,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2960,12 +2879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,12 +2889,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2996,22 +2903,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3026,12 +2921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,12 +2931,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3062,12 +2945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,12 +2955,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,14 +41,13 @@ toml = "0.8"
 rusqlite = { version = "0.32", features = ["bundled"] }
 
 # Terminal detection
-terminal_size = "0.4"
 
 # HTTP (for pricing data fetch)
 ureq = { version = "2", default-features = false, features = ["tls", "native-certs", "json"] }
 
 # TUI (tokemon top)
 ratatui = { version = "0.30", features = ["crossterm"] }
-crossterm = { version = "0.28", features = ["event-stream"] }
+crossterm = { version = "0.29", features = ["event-stream"] }
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
 futures-lite = "2"
 notify = "7"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,7 +18,7 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub fn open() -> anyhow::Result<Self> {
+    pub fn open() -> crate::error::Result<Self> {
         let db_path = Self::db_path();
         if let Some(parent) = db_path.parent() {
             fs::create_dir_all(parent)?;
@@ -60,7 +60,7 @@ impl Cache {
         paths::cache_dir().join(DB_FILENAME)
     }
 
-    fn init_schema(&self) -> anyhow::Result<()> {
+    fn init_schema(&self) -> crate::error::Result<()> {
         // Create tables with individual statements so failures are isolated
         // and provide clear error messages.
         self.conn.execute(
@@ -133,7 +133,7 @@ impl Cache {
 
     /// Verify the database is actually writable by doing a round-trip
     /// write/read/delete to `cache_meta`.
-    fn verify_writable(&self) -> anyhow::Result<()> {
+    fn verify_writable(&self) -> crate::error::Result<()> {
         self.conn.execute(
             "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('_write_test', '1')",
             [],
@@ -143,17 +143,20 @@ impl Cache {
             [],
             |row| row.get(0),
         )?;
-        anyhow::ensure!(
-            val == "1",
-            "cache write verification failed: read back '{val}'"
-        );
+        if val != "1" {
+            return Err(crate::error::TokemonError::Cache(format!(
+                "cache write verification failed: read back '{val}'"
+            )));
+        }
         self.conn
             .execute("DELETE FROM cache_meta WHERE key = '_write_test'", [])?;
         Ok(())
     }
 
     /// Get all cached (file, mtime) pairs in one query for bulk staleness checking.
-    pub fn cached_file_mtimes(&self) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+    pub fn cached_file_mtimes(
+        &self,
+    ) -> crate::error::Result<std::collections::HashMap<String, i64>> {
         let mut map = std::collections::HashMap::new();
         let mut stmt = self.conn.prepare(
             "SELECT source_file, MAX(source_mtime) FROM usage_entries GROUP BY source_file",
@@ -173,7 +176,7 @@ impl Cache {
         cost_usd, message_id, request_id, session_id";
 
     /// Load ALL cached entries in one query.
-    pub fn load_all_entries(&self) -> anyhow::Result<Vec<Record>> {
+    pub fn load_all_entries(&self) -> crate::error::Result<Vec<Record>> {
         let sql = format!(
             "SELECT {} FROM usage_entries ORDER BY timestamp",
             Self::ENTRY_COLUMNS
@@ -199,7 +202,7 @@ impl Cache {
         since: Option<NaiveDate>,
         until: Option<NaiveDate>,
         providers: &[String],
-    ) -> anyhow::Result<Vec<Record>> {
+    ) -> crate::error::Result<Vec<Record>> {
         let mut conditions: Vec<String> = Vec::new();
         let mut param_values: Vec<Value> = Vec::new();
 
@@ -258,7 +261,7 @@ impl Cache {
         path: &Path,
         mtime_secs: i64,
         entries: &[Record],
-    ) -> anyhow::Result<()> {
+    ) -> crate::error::Result<()> {
         let path_str = path.display().to_string();
 
         self.conn.execute(
@@ -304,7 +307,10 @@ impl Cache {
     /// semantics. On success, also updates the discovery timestamp.
     ///
     /// Returns the total number of entries written.
-    pub fn write_entries(&mut self, files: &[(&Path, i64, Vec<Record>)]) -> anyhow::Result<usize> {
+    pub fn write_entries(
+        &mut self,
+        files: &[(&Path, i64, Vec<Record>)],
+    ) -> crate::error::Result<usize> {
         if files.is_empty() {
             return Ok(0);
         }
@@ -393,7 +399,7 @@ impl Cache {
     }
 
     /// Record the current time as the last discovery timestamp.
-    pub fn set_last_discovery(&self) -> anyhow::Result<()> {
+    pub fn set_last_discovery(&self) -> crate::error::Result<()> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -410,7 +416,7 @@ impl Cache {
     pub fn mark_preserved(
         &self,
         discovered_files: &std::collections::HashSet<String>,
-    ) -> anyhow::Result<()> {
+    ) -> crate::error::Result<()> {
         if discovered_files.is_empty() {
             return Ok(());
         }
@@ -434,7 +440,7 @@ impl Cache {
     }
 
     /// Delete preserved entries with timestamps before the given date.
-    pub fn prune_before(&self, before: NaiveDate) -> anyhow::Result<usize> {
+    pub fn prune_before(&self, before: NaiveDate) -> crate::error::Result<usize> {
         let before_str = before.to_string();
         let deleted = self.conn.execute(
             "DELETE FROM usage_entries WHERE preserved = 1 AND timestamp < ?1",

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum TokemonError {
 
     #[error("Pricing error: {0}")]
     Pricing(String),
+
+    #[error("Cache error: {0}")]
+    Cache(String),
 }
 
 pub type Result<T> = std::result::Result<T, TokemonError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ mod types;
 use cache::Cache;
 use cli::{Cli, Commands, Frequency};
 use config::Config;
-use pipeline::{load_and_price, resolve_providers};
+use pipeline::{load_and_price};
 use source::SourceSet;
 use types::{Report, SessionReport};
 
@@ -74,7 +74,7 @@ fn cmd_discover() {
         .all()
         .iter()
         .map(|p| {
-            let available = p.is_available();
+            let available = !p.discover_files().is_empty();
             let data_dir = p.data_dir().display().to_string();
             let file_count = if available {
                 p.discover_files().len()
@@ -125,7 +125,7 @@ fn cmd_report(cli: &Cli, config: &Config) -> anyhow::Result<()> {
         Frequency::Weekly => "weekly",
         Frequency::Monthly => "monthly",
     };
-    let entries = load_and_price(cli, config, false, cli.since, cli.until)?;
+    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
 
     if entries.is_empty() {
         let empty_report = Report {
@@ -147,7 +147,8 @@ fn cmd_report(cli: &Cli, config: &Config) -> anyhow::Result<()> {
             }
         } else {
             println!("No usage data found.");
-            if resolve_providers(cli, config).is_empty() {
+            let pipeline_opts = pipeline::PipelineOptions::from_cli_config(cli, config);
+            if pipeline_opts.providers.is_empty() {
                 println!("Run `tokemon discover` to see which providers are available.");
             }
         }
@@ -204,7 +205,7 @@ fn cmd_statusline(cli: &Cli, config: &Config) -> anyhow::Result<()> {
     let freq = cli.frequency;
     let since = frequency_since(freq);
     let effective_since = merge_since(cli.since, Some(since));
-    let entries = load_and_price(cli, config, true, effective_since, cli.until)?;
+    let entries = load_and_price(&pipeline::PipelineOptions { since: effective_since, ..pipeline::PipelineOptions::from_cli_config(cli, config) }, true)?;
     let period_label = match freq {
         Frequency::Daily => "today",
         Frequency::Weekly => "this week",
@@ -254,14 +255,14 @@ fn cmd_statusline(cli: &Cli, config: &Config) -> anyhow::Result<()> {
 }
 
 fn cmd_budget(cli: &Cli, config: &Config) -> anyhow::Result<()> {
-    let entries = load_and_price(cli, config, false, cli.since, cli.until)?;
+    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
     let status = pacemaker::evaluate(&entries, &config.budget);
     render::print_budget(&status);
     Ok(())
 }
 
 fn cmd_sessions(cli: &Cli, config: &Config, top: usize) -> anyhow::Result<()> {
-    let entries = load_and_price(cli, config, false, cli.since, cli.until)?;
+    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
 
     if entries.is_empty() {
         let empty_report = SessionReport {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> anyhow::Result<()> {
 fn cmd_discover() {
     let registry = SourceSet::new();
 
-    let info: Vec<(&str, &str, bool, String, usize)> = registry
+    let info: Vec<crate::types::ProviderInfo> = registry
         .all()
         .iter()
         .map(|p| {
@@ -81,7 +81,13 @@ fn cmd_discover() {
             } else {
                 0
             };
-            (p.name(), p.display_name(), available, data_dir, file_count)
+            crate::types::ProviderInfo {
+                name: p.name().to_string(),
+                display_name: p.display_name().to_string(),
+                available,
+                data_dir,
+                file_count,
+            }
         })
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ mod types;
 use cache::Cache;
 use cli::{Cli, Commands, Frequency};
 use config::Config;
-use pipeline::{load_and_price};
+use pipeline::load_and_price;
 use source::SourceSet;
 use types::{Report, SessionReport};
 
@@ -131,7 +131,10 @@ fn cmd_report(cli: &Cli, config: &Config) -> anyhow::Result<()> {
         Frequency::Weekly => "weekly",
         Frequency::Monthly => "monthly",
     };
-    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
+    let entries = load_and_price(
+        &pipeline::PipelineOptions::from_cli_config(cli, config),
+        false,
+    )?;
 
     if entries.is_empty() {
         let empty_report = Report {
@@ -211,7 +214,13 @@ fn cmd_statusline(cli: &Cli, config: &Config) -> anyhow::Result<()> {
     let freq = cli.frequency;
     let since = frequency_since(freq);
     let effective_since = merge_since(cli.since, Some(since));
-    let entries = load_and_price(&pipeline::PipelineOptions { since: effective_since, ..pipeline::PipelineOptions::from_cli_config(cli, config) }, true)?;
+    let entries = load_and_price(
+        &pipeline::PipelineOptions {
+            since: effective_since,
+            ..pipeline::PipelineOptions::from_cli_config(cli, config)
+        },
+        true,
+    )?;
     let period_label = match freq {
         Frequency::Daily => "today",
         Frequency::Weekly => "this week",
@@ -261,14 +270,20 @@ fn cmd_statusline(cli: &Cli, config: &Config) -> anyhow::Result<()> {
 }
 
 fn cmd_budget(cli: &Cli, config: &Config) -> anyhow::Result<()> {
-    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
+    let entries = load_and_price(
+        &pipeline::PipelineOptions::from_cli_config(cli, config),
+        false,
+    )?;
     let status = pacemaker::evaluate(&entries, &config.budget);
     render::print_budget(&status);
     Ok(())
 }
 
 fn cmd_sessions(cli: &Cli, config: &Config, top: usize) -> anyhow::Result<()> {
-    let entries = load_and_price(&pipeline::PipelineOptions::from_cli_config(cli, config), false)?;
+    let entries = load_and_price(
+        &pipeline::PipelineOptions::from_cli_config(cli, config),
+        false,
+    )?;
 
     if entries.is_empty() {
         let empty_report = SessionReport {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -199,7 +199,7 @@ fn handle_tools_call(id: &Value, request: &Value, cli: &Cli, config: &Config) ->
 // boundary between internal `anyhow::Error` and the MCP wire format.
 fn tool_usage_today(cli: &Cli, config: &Config) -> Result<String, String> {
     let today = chrono::Utc::now().date_naive();
-    let entries = crate::pipeline::load_and_price(cli, config, true, Some(today), None)
+    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: Some(today), ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
         .map_err(|e| e.to_string())?;
     let mut total_tokens = 0u64;
     let mut total_cost = 0.0f64;
@@ -230,7 +230,7 @@ fn tool_usage_period(cli: &Cli, config: &Config, args: &Value) -> Result<String,
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<chrono::NaiveDate>().ok());
 
-    let entries = crate::pipeline::load_and_price(cli, config, true, since, until)
+    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since, until, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
         .map_err(|e| e.to_string())?;
 
     let entries = rollup::filter_by_date(entries, since, until);
@@ -262,7 +262,7 @@ fn tool_usage_period(cli: &Cli, config: &Config, args: &Value) -> Result<String,
 }
 
 fn tool_budget_status(cli: &Cli, config: &Config) -> Result<String, String> {
-    let entries = crate::pipeline::load_and_price(cli, config, true, None, None)
+    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: None, until: None, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
         .map_err(|e| e.to_string())?;
     let status = crate::pacemaker::evaluate(&entries, &config.budget);
 
@@ -289,7 +289,7 @@ fn tool_session_cost(cli: &Cli, config: &Config, args: &Value) -> Result<String,
         .and_then(|v| v.as_str())
         .ok_or_else(|| "session_id is required".to_string())?;
 
-    let entries = crate::pipeline::load_and_price(cli, config, true, None, None)
+    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: None, until: None, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
         .map_err(|e| e.to_string())?;
     let sessions = rollup::aggregate_by_session(&entries);
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -20,9 +20,7 @@ pub fn run(cli: &Cli, config: &Config) -> anyhow::Result<()> {
     let mut stdout = io::stdout();
 
     for line in stdin.lock().lines() {
-        let Ok(line) = line else {
-            break;
-        };
+        let line = line?;
 
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -199,8 +197,14 @@ fn handle_tools_call(id: &Value, request: &Value, cli: &Cli, config: &Config) ->
 // boundary between internal `anyhow::Error` and the MCP wire format.
 fn tool_usage_today(cli: &Cli, config: &Config) -> Result<String, String> {
     let today = chrono::Utc::now().date_naive();
-    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: Some(today), ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
-        .map_err(|e| e.to_string())?;
+    let entries = crate::pipeline::load_and_price(
+        &crate::pipeline::PipelineOptions {
+            since: Some(today),
+            ..crate::pipeline::PipelineOptions::from_cli_config(cli, config)
+        },
+        true,
+    )
+    .map_err(|e| e.to_string())?;
     let mut total_tokens = 0u64;
     let mut total_cost = 0.0f64;
 
@@ -221,17 +225,32 @@ fn tool_usage_today(cli: &Cli, config: &Config) -> Result<String, String> {
 }
 
 fn tool_usage_period(cli: &Cli, config: &Config, args: &Value) -> Result<String, String> {
-    let since = args
-        .get("since")
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.parse::<chrono::NaiveDate>().ok());
-    let until = args
-        .get("until")
-        .and_then(|v| v.as_str())
-        .and_then(|s| s.parse::<chrono::NaiveDate>().ok());
+    let since = if let Some(v) = args.get("since").and_then(|v| v.as_str()) {
+        Some(
+            v.parse::<chrono::NaiveDate>()
+                .map_err(|_| format!("Invalid date format for 'since': {v}"))?,
+        )
+    } else {
+        None
+    };
+    let until = if let Some(v) = args.get("until").and_then(|v| v.as_str()) {
+        Some(
+            v.parse::<chrono::NaiveDate>()
+                .map_err(|_| format!("Invalid date format for 'until': {v}"))?,
+        )
+    } else {
+        None
+    };
 
-    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since, until, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
-        .map_err(|e| e.to_string())?;
+    let entries = crate::pipeline::load_and_price(
+        &crate::pipeline::PipelineOptions {
+            since,
+            until,
+            ..crate::pipeline::PipelineOptions::from_cli_config(cli, config)
+        },
+        true,
+    )
+    .map_err(|e| e.to_string())?;
 
     let entries = rollup::filter_by_date(entries, since, until);
 
@@ -262,8 +281,15 @@ fn tool_usage_period(cli: &Cli, config: &Config, args: &Value) -> Result<String,
 }
 
 fn tool_budget_status(cli: &Cli, config: &Config) -> Result<String, String> {
-    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: None, until: None, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
-        .map_err(|e| e.to_string())?;
+    let entries = crate::pipeline::load_and_price(
+        &crate::pipeline::PipelineOptions {
+            since: None,
+            until: None,
+            ..crate::pipeline::PipelineOptions::from_cli_config(cli, config)
+        },
+        true,
+    )
+    .map_err(|e| e.to_string())?;
     let status = crate::pacemaker::evaluate(&entries, &config.budget);
 
     let to_json = |bp: &crate::pacemaker::BudgetPeriod| {
@@ -289,8 +315,15 @@ fn tool_session_cost(cli: &Cli, config: &Config, args: &Value) -> Result<String,
         .and_then(|v| v.as_str())
         .ok_or_else(|| "session_id is required".to_string())?;
 
-    let entries = crate::pipeline::load_and_price(&crate::pipeline::PipelineOptions { since: None, until: None, ..crate::pipeline::PipelineOptions::from_cli_config(cli, config) }, true)
-        .map_err(|e| e.to_string())?;
+    let entries = crate::pipeline::load_and_price(
+        &crate::pipeline::PipelineOptions {
+            since: None,
+            until: None,
+            ..crate::pipeline::PipelineOptions::from_cli_config(cli, config)
+        },
+        true,
+    )
+    .map_err(|e| e.to_string())?;
     let sessions = rollup::aggregate_by_session(&entries);
 
     let matched: Vec<_> = sessions

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -52,7 +52,7 @@ impl PipelineOptions {
 pub fn load_and_price(
     opts: &PipelineOptions,
     force_offline: bool,
-) -> anyhow::Result<Vec<types::Record>> {
+) -> crate::error::Result<Vec<types::Record>> {
     let registry = SourceSet::new();
     let mut entries = parse_with_cache(&registry, opts)?;
 
@@ -79,7 +79,7 @@ pub fn load_and_price(
 fn parse_with_cache(
     registry: &SourceSet,
     opts: &PipelineOptions,
-) -> anyhow::Result<Vec<types::Record>> {
+) -> crate::error::Result<Vec<types::Record>> {
     let mut cache = match Cache::open() {
         Ok(c) => Some(c),
         Err(e) => {
@@ -210,7 +210,7 @@ fn parse_with_cache(
 fn resolve_source_refs<'a>(
     registry: &'a SourceSet,
     filter: &[String],
-) -> anyhow::Result<Vec<&'a dyn source::Source>> {
+) -> crate::error::Result<Vec<&'a dyn source::Source>> {
     if filter.is_empty() {
         return Ok(registry.available());
     }
@@ -220,7 +220,7 @@ fn resolve_source_refs<'a>(
         .map(|name| {
             registry
                 .get(name)
-                .ok_or_else(|| error::TokemonError::ProviderNotFound(name.clone()).into())
+                .ok_or_else(|| error::TokemonError::ProviderNotFound(name.clone()))
         })
         .collect()
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -17,39 +17,47 @@ use crate::types;
 
 const REDISCOVERY_INTERVAL_SECS: u64 = 30;
 
-/// Resolve which providers to use: CLI `--provider` flags override config defaults.
-pub fn resolve_providers<'a>(cli: &'a Cli, config: &'a Config) -> &'a [String] {
-    if cli.providers.is_empty() {
-        &config.providers
-    } else {
-        &cli.providers
+#[derive(Debug, Clone, Default)]
+pub struct PipelineOptions {
+    pub providers: Vec<String>,
+    pub since: Option<NaiveDate>,
+    pub until: Option<NaiveDate>,
+    pub no_cost: bool,
+    pub offline: bool,
+    pub refresh: bool,
+    pub reparse: bool,
+}
+
+impl PipelineOptions {
+    #[must_use]
+    pub fn from_cli_config(cli: &Cli, config: &Config) -> Self {
+        Self {
+            providers: if cli.providers.is_empty() {
+                config.providers.clone()
+            } else {
+                cli.providers.clone()
+            },
+            since: cli.since,
+            until: cli.until,
+            no_cost: cli.no_cost || config.no_cost,
+            offline: cli.offline || config.offline,
+            refresh: cli.refresh || config.refresh,
+            reparse: cli.reparse || config.reparse,
+        }
     }
 }
 
 /// Load usage entries from all matching providers, parse via cache, and
 /// optionally apply pricing.
 pub fn load_and_price(
-    cli: &Cli,
-    config: &Config,
+    opts: &PipelineOptions,
     force_offline: bool,
-    since: Option<NaiveDate>,
-    until: Option<NaiveDate>,
 ) -> anyhow::Result<Vec<types::Record>> {
     let registry = SourceSet::new();
-    let filter = resolve_providers(cli, config);
-    let force_refresh = cli.refresh || config.refresh;
-    let force_reparse = cli.reparse || config.reparse;
-    let mut entries = parse_with_cache(
-        &registry,
-        filter,
-        force_refresh,
-        force_reparse,
-        since,
-        until,
-    )?;
+    let mut entries = parse_with_cache(&registry, opts)?;
 
-    if !(cli.no_cost || config.no_cost) {
-        let offline = force_offline || cli.offline || config.offline;
+    if !opts.no_cost {
+        let offline = force_offline || opts.offline;
         match cost::PricingEngine::load(offline) {
             Ok(engine) => engine.apply_costs(&mut entries),
             Err(e) => {
@@ -70,11 +78,7 @@ pub fn load_and_price(
 /// 4. Load everything from cache in one bulk query
 fn parse_with_cache(
     registry: &SourceSet,
-    filter: &[String],
-    force_refresh: bool,
-    force_reparse: bool,
-    since: Option<NaiveDate>,
-    until: Option<NaiveDate>,
+    opts: &PipelineOptions,
 ) -> anyhow::Result<Vec<types::Record>> {
     let mut cache = match Cache::open() {
         Ok(c) => Some(c),
@@ -84,18 +88,18 @@ fn parse_with_cache(
         }
     };
 
-    let providers = resolve_source_refs(registry, filter)?;
+    let providers = resolve_source_refs(registry, &opts.providers)?;
 
     let Some(ref mut cache) = cache else {
         return Ok(parse_all_directly(&providers));
     };
 
-    let has_filters = since.is_some() || until.is_some() || !filter.is_empty();
+    let has_filters = opts.since.is_some() || opts.until.is_some() || !opts.providers.is_empty();
 
     // If cache is fresh and no --refresh/--reparse flag, skip discovery entirely
-    if !force_refresh && !force_reparse && !cache.should_rediscover(REDISCOVERY_INTERVAL_SECS) {
+    if !opts.refresh && !opts.reparse && !cache.should_rediscover(REDISCOVERY_INTERVAL_SECS) {
         let mut entries = if has_filters {
-            cache.load_entries_filtered(since, until, filter)?
+            cache.load_entries_filtered(opts.since, opts.until, &opts.providers)?
         } else {
             cache.load_all_entries()?
         };
@@ -105,7 +109,7 @@ fn parse_with_cache(
     }
 
     // When --reparse, ignore cached mtimes so every file gets re-parsed
-    let cached_mtimes = if force_reparse {
+    let cached_mtimes = if opts.reparse {
         std::collections::HashMap::new()
     } else {
         cache.cached_file_mtimes().unwrap_or_default()
@@ -130,7 +134,7 @@ fn parse_with_cache(
     // Mark entries from deleted files as preserved (only when discovering all providers,
     // otherwise we'd incorrectly mark entries from non-filtered providers).
     // Best-effort: log a warning if it fails rather than aborting the pipeline.
-    if filter.is_empty() {
+    if opts.providers.is_empty() {
         if let Err(e) = cache.mark_preserved(&discovered_files) {
             eprintln!("[tokemon] Warning: failed to mark preserved entries: {e}");
         }
@@ -194,7 +198,7 @@ fn parse_with_cache(
     }
 
     let mut entries = if has_filters {
-        cache.load_entries_filtered(since, until, filter)?
+        cache.load_entries_filtered(opts.since, opts.until, &opts.providers)?
     } else {
         cache.load_all_entries()?
     };

--- a/src/render/helpers.rs
+++ b/src/render/helpers.rs
@@ -95,23 +95,23 @@ fn ansi(code: &str, s: &str, color: bool) -> String {
     }
 }
 
-pub fn bold(s: &str, c: bool) -> String {
-    ansi("1", s, c)
+pub fn bold(s: &str, color: bool) -> String {
+    ansi("1", s, color)
 }
-pub fn dim(s: &str, c: bool) -> String {
-    ansi("2", s, c)
+pub fn dim(s: &str, color: bool) -> String {
+    ansi("2", s, color)
 }
-pub fn cyan_bold(s: &str, c: bool) -> String {
-    ansi("1;36", s, c)
+pub fn cyan_bold(s: &str, color: bool) -> String {
+    ansi("1;36", s, color)
 }
-pub fn green(s: &str, c: bool) -> String {
-    ansi("32", s, c)
+pub fn green(s: &str, color: bool) -> String {
+    ansi("32", s, color)
 }
-pub fn yellow(s: &str, c: bool) -> String {
-    ansi("33", s, c)
+pub fn yellow(s: &str, color: bool) -> String {
+    ansi("33", s, color)
 }
-pub fn red(s: &str, c: bool) -> String {
-    ansi("31", s, c)
+pub fn red(s: &str, color: bool) -> String {
+    ansi("31", s, color)
 }
 
 /// Apply bold to every element in a row.

--- a/src/render/helpers.rs
+++ b/src/render/helpers.rs
@@ -143,7 +143,7 @@ pub fn style_header(header: &mut [String], color: bool) {
 /// Terminal width in visible columns.
 #[must_use]
 pub fn terminal_width() -> usize {
-    terminal_size::terminal_size().map_or(120, |(w, _)| w.0 as usize)
+    crossterm::terminal::size().map_or(120, |(w, _)| w as usize)
 }
 
 /// Visible width of a string, ignoring ANSI escape codes.

--- a/src/render/table.rs
+++ b/src/render/table.rs
@@ -542,21 +542,19 @@ fn progress_bar(pct: f64, width: usize) -> String {
     format!("{}{}", "#".repeat(filled), "-".repeat(empty))
 }
 
-pub fn print_discover(providers: &[(&str, &str, bool, String, usize)]) {
+pub fn print_discover(providers: &[crate::types::ProviderInfo]) {
     let rows: Vec<DiscoverRow> = providers
         .iter()
-        .map(
-            |(name, display, available, data_dir, file_count)| DiscoverRow {
-                provider: format!("{display} ({name})"),
-                status: if *available {
-                    "Found".to_string()
-                } else {
-                    "None".to_string()
-                },
-                data_dir: data_dir.clone(),
-                files: format_tokens(*file_count as u64),
+        .map(|info| DiscoverRow {
+            provider: format!("{} ({})", info.display_name, info.name),
+            status: if info.available {
+                "Found".to_string()
+            } else {
+                "None".to_string()
             },
-        )
+            data_dir: info.data_dir.clone(),
+            files: format_tokens(info.file_count as u64),
+        })
         .collect();
 
     let table = Table::new(&rows).with(Style::rounded()).to_string();

--- a/src/source/jsonl_source.rs
+++ b/src/source/jsonl_source.rs
@@ -101,11 +101,25 @@ impl<C: JsonlSourceConfig> super::Source for JsonlSource<C> {
         let reader = BufReader::with_capacity(64 * 1024, file);
         let session_id = timestamp::extract_session_id(path);
 
+        let mut error_logged = false;
         let entries = reader
             .lines()
             .map_while(std::result::Result::ok)
             .filter(|line| line.contains("\"assistant\"") || line.contains("\"response\""))
-            .filter_map(|line| serde_json::from_str::<JsonlLine>(&line).ok())
+            .filter_map(|line| match serde_json::from_str::<JsonlLine>(&line) {
+                Ok(parsed) => Some(parsed),
+                Err(e) => {
+                    if !error_logged {
+                        eprintln!(
+                            "[tokemon] Warning: skipped malformed JSON in {}: {}",
+                            path.display(),
+                            e
+                        );
+                        error_logged = true;
+                    }
+                    None
+                }
+            })
             .filter(|parsed| matches!(parsed.line_type.as_deref(), Some("assistant" | "response")))
             .filter_map(|parsed| {
                 let usage = parsed.usage?;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -34,7 +34,7 @@ pub trait Source: Send + Sync {
     /// Human-readable: "Claude Code", "Codex CLI", "Gemini CLI"
     fn display_name(&self) -> &'static str;
 
-    /// Return the base data directory for display purposes
+    /// Get the absolute path to the base data directory
     fn data_dir(&self) -> PathBuf;
 
     /// Return all data files for this provider on this machine
@@ -42,11 +42,6 @@ pub trait Source: Send + Sync {
 
     /// Parse one file into usage entries
     fn parse_file(&self, path: &Path) -> Result<Vec<Record>>;
-
-    /// Whether this provider has any data
-    fn is_available(&self) -> bool {
-        !self.discover_files().is_empty()
-    }
 
     /// Parse all files in parallel with dedup.
     ///
@@ -105,7 +100,7 @@ impl SourceSet {
     pub fn available(&self) -> Vec<&dyn Source> {
         self.providers
             .iter()
-            .filter(|p| p.is_available())
+            .filter(|p| !p.discover_files().is_empty())
             .map(std::convert::AsRef::as_ref)
             .collect()
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -288,13 +288,23 @@ impl App {
         // cached pricing.json). If the cache doesn't exist yet (fresh
         // install), fall back to a one-time online fetch.
         if !config.no_cost {
-            app.pricing = cost::PricingEngine::load(true).ok();
-            if app
-                .pricing
-                .as_ref()
-                .is_some_and(cost::PricingEngine::is_empty)
-            {
-                app.pricing = cost::PricingEngine::load(false).ok();
+            match cost::PricingEngine::load(true) {
+                Ok(engine) => {
+                    if engine.is_empty() {
+                        match cost::PricingEngine::load(false) {
+                            Ok(online_engine) => app.pricing = Some(online_engine),
+                            Err(e) => {
+                                app.last_warning =
+                                    Some((format!("Pricing unavailable: {e}"), Instant::now()));
+                            }
+                        }
+                    } else {
+                        app.pricing = Some(engine);
+                    }
+                }
+                Err(e) => {
+                    app.last_warning = Some((format!("Pricing unavailable: {e}"), Instant::now()));
+                }
             }
         }
         // Compute all-time base from historical records (before the

--- a/src/tui/watcher.rs
+++ b/src/tui/watcher.rs
@@ -88,7 +88,7 @@ fn run_watcher(event_tx: &mpsc::UnboundedSender<Event>) -> anyhow::Result<()> {
 
                 if has_changes {
                     // Re-parse changed files and update the cache
-                    if let Err(e) = incremental_update(&registry) {
+                    if let Err(e) = incremental_update(&registry, event_tx) {
                         warn(event_tx, format!("Incremental update failed: {e}"));
                     }
 
@@ -117,7 +117,10 @@ fn run_watcher(event_tx: &mpsc::UnboundedSender<Event>) -> anyhow::Result<()> {
 /// This mirrors the logic in `main.rs::parse_with_cache` but is designed
 /// to run from a background thread. It only re-parses files whose
 /// modification time has changed since the last cache write.
-fn incremental_update(registry: &SourceSet) -> anyhow::Result<()> {
+fn incremental_update(
+    registry: &SourceSet,
+    event_tx: &mpsc::UnboundedSender<Event>,
+) -> anyhow::Result<()> {
     let mut cache = cache::Cache::open()?;
     let cached_mtimes = cache.cached_file_mtimes()?;
 
@@ -156,7 +159,7 @@ fn incremental_update(registry: &SourceSet) -> anyhow::Result<()> {
             Err(e) => {
                 // Log but continue — don't let one bad file block others.
                 // This will be reported via Event::Warning by the caller.
-                eprintln!("[tokemon] Warning: failed to parse {}: {e}", file.display());
+                warn(event_tx, format!("failed to parse {}: {e}", file.display()));
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,16 @@ use std::borrow::Cow;
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Information about a discovered usage provider
+#[derive(Debug, Clone)]
+pub struct ProviderInfo {
+    pub name: String,
+    pub display_name: String,
+    pub available: bool,
+    pub data_dir: String,
+    pub file_count: usize,
+}
+
 /// A single usage entry from any provider
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Record {


### PR DESCRIPTION
## Summary
Resolved several final pedantic and architectural contract issues raised by desloppify.

## Changes
- **API Surface**: Unified error contracts across Cache and Pipeline to use typed `crate::error::Result`, adding a `Cache` error variant. Extracted `PipelineOptions` struct to replace wide config bags. Removed hidden I/O from `is_available()` trait.
- **Dependency Health**: Bumped `crossterm` to 0.29 to perfectly align with ratatui and removed the `terminal_size` crate since crossterm already exposes the needed API.
- **MCP Server**: Fixed stdin read loop to correctly propagate I/O errors rather than gracefully exiting. Validated date inputs to return JSON-RPC errors instead of silently swallowing formatting issues.
- **TUI & Watcher**: Replaced background thread `eprintln!` usage with `Event::Warning` channels to prevent terminal UI layout corruption. Ensured PricingEngine load errors don't silently fail but instead populate the TUI status bar.