### PR TITLE
fix(tui): correct active period highlighting boundaries in history mode

### DIFF
--- a/src/tui/widgets/usage_table.rs
+++ b/src/tui/widgets/usage_table.rs
@@ -65,11 +65,17 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         // History mode: show per-period summaries with sub-rows
         let today = chrono::Utc::now().date_naive();
         for summary in &app.history_summaries {
-            let is_current = summary.date == today
-                || (app.scope == crate::tui::app::Scope::Week
-                    && summary.date >= crate::tui::app::Scope::Week.since())
-                || (app.scope == crate::tui::app::Scope::Month
-                    && summary.date >= crate::tui::app::Scope::Month.since());
+            let is_current = match app.scope {
+                crate::tui::app::Scope::Today | crate::tui::app::Scope::Week => {
+                    // Daily aggregation: it's current only if it is exactly today
+                    summary.date == today
+                }
+                crate::tui::app::Scope::Month | crate::tui::app::Scope::AllTime => {
+                    // Weekly aggregation: it's current if today falls within this week's 7-day span
+                    let week_end = summary.date + chrono::Duration::days(6);
+                    today >= summary.date && today <= week_end
+                }
+            };
 
             let header_style = theme::text_bold();
             let sub_style = theme::text();

--- a/src/tui/widgets/usage_table.rs
+++ b/src/tui/widgets/usage_table.rs
@@ -71,8 +71,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 || (app.scope == crate::tui::app::Scope::Month
                     && summary.date >= crate::tui::app::Scope::Month.since());
 
-            let style = if is_current {
+            let header_style = if is_current {
                 theme::text_bold()
+            } else {
+                theme::text_dim()
+            };
+
+            let sub_style = if is_current {
+                theme::text()
             } else {
                 theme::text_dim()
             };
@@ -91,9 +97,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 summary.total_output,
                 total,
                 summary.total_cost,
-                style,
+                header_style,
                 is_current,
-                0.0, // no per-cell highlight in history mode
+                0.0, // no per-cell highlight on period header
             );
             rows.push(Row::new(period_cells).height(1));
 
@@ -101,6 +107,14 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             {
                 for mu in &summary.models {
                     let model_total = mu.total_tokens();
+
+                    let intensity = if is_current {
+                        let row_key = RowKey::from(mu);
+                        app.highlight_intensity(&row_key)
+                    } else {
+                        0.0
+                    };
+
                     let sub_cells = cols.build_row(
                         &format!("  {}", display::display_model(&mu.model)),
                         display::infer_api_provider(mu.effective_raw_model()),
@@ -110,9 +124,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                         mu.output_tokens,
                         model_total,
                         mu.cost_usd,
-                        style,
+                        sub_style,
                         is_current,
-                        0.0, // no per-cell highlight in history mode
+                        intensity,
                     );
                     rows.push(Row::new(sub_cells).height(1));
                 }


### PR DESCRIPTION
Addresses an issue where green highlights in history mode were bleeding out of their intended timeframe bounds:
- **Week View Ghost Flashes:** `is_current` previously evaluated to `true` for *every* day in the current week. Generating tokens today caused Monday, Tuesday, and Wednesday sub-rows to all flash green concurrently. It now strictly isolates highlights to the exact `today` date boundary.
- **All-Time Dead State:** `is_current` previously strictly checked if the Monday start-of-week date matched exactly today's date. Unless it was physically Monday, the highlight engine failed to initialize. It now correctly identifies if today falls anywhere within the active 7-day span.