### PR TITLE
fix: re-price zero-cost records and improve error resilience

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -423,7 +423,19 @@ impl Cache {
             .prepare("SELECT DISTINCT source_file FROM usage_entries WHERE preserved = 0")?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
 
-        let cached_files: Vec<String> = rows.flatten().collect();
+        let mut skipped = 0u64;
+        let mut cached_files = Vec::new();
+        for row in rows {
+            match row {
+                Ok(file) => cached_files.push(file),
+                Err(_) => skipped += 1,
+            }
+        }
+        if skipped > 0 {
+            eprintln!(
+                "[tokemon] Warning: skipped {skipped} cached rows while checking preserved files"
+            );
+        }
         for file in &cached_files {
             if !discovered_files.contains(file) {
                 self.conn.execute(

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -107,11 +107,15 @@ impl PricingEngine {
         let mut pricing_cache: HashMap<&str, Option<&ModelPricing>> = HashMap::new();
 
         for entry in entries.iter_mut() {
-            // If entry already has a cost (even $0.00), keep it.
-            // Some(0.0) means "already priced, result was zero" (e.g.
-            // free model or no pricing data). Re-pricing would cause
+            // Skip records that already have a positive cost — these were
+            // priced correctly on a previous run and re-pricing would cause
             // cost fluctuations when records are loaded from cache.
-            if entry.cost_usd.is_some() {
+            //
+            // Records with `Some(0.0)` are treated as *unpriced*: some
+            // source parsers store `cost: 0` when they don't know the
+            // price for a model, so we give the pricing engine a chance
+            // to fill in the real cost.
+            if entry.cost_usd.is_some_and(|c| c > 0.0) {
                 continue;
             }
 
@@ -367,5 +371,88 @@ mod tests {
             .find_pricing("gpt-4-32k-0613")
             .expect("should prefix match gpt-4-32k");
         assert_eq!(p2.input_cost_per_token, Some(0.06));
+    }
+
+    #[test]
+    fn test_zero_cost_gets_repriced() {
+        use chrono::Utc;
+        use std::borrow::Cow;
+
+        let engine = PricingEngine::parse_pricing(DUMMY_JSON).unwrap();
+
+        let mut records = vec![
+            // Record with cost_usd = Some(0.0) should be re-priced
+            Record {
+                timestamp: Utc::now(),
+                provider: Cow::Borrowed("test"),
+                model: Some("model-a".to_string()),
+                input_tokens: 1000,
+                output_tokens: 500,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                thinking_tokens: 0,
+                cost_usd: Some(0.0),
+                message_id: None,
+                request_id: None,
+                session_id: None,
+            },
+            // Record with a positive cost should be kept as-is
+            Record {
+                timestamp: Utc::now(),
+                provider: Cow::Borrowed("test"),
+                model: Some("model-a".to_string()),
+                input_tokens: 1000,
+                output_tokens: 500,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                thinking_tokens: 0,
+                cost_usd: Some(99.0),
+                message_id: None,
+                request_id: None,
+                session_id: None,
+            },
+            // Record with cost_usd = None should also be priced
+            Record {
+                timestamp: Utc::now(),
+                provider: Cow::Borrowed("test"),
+                model: Some("model-a".to_string()),
+                input_tokens: 1000,
+                output_tokens: 500,
+                cache_read_tokens: 0,
+                cache_creation_tokens: 0,
+                thinking_tokens: 0,
+                cost_usd: None,
+                message_id: None,
+                request_id: None,
+                session_id: None,
+            },
+        ];
+
+        engine.apply_costs(&mut records);
+
+        // model-a: input=0.001, output=0.002
+        // expected = 1000 * 0.001 + 500 * 0.002 = 1.0 + 1.0 = 2.0
+        let expected_cost = 2.0;
+
+        // Some(0.0) record got re-priced
+        assert_eq!(
+            records[0].cost_usd,
+            Some(expected_cost),
+            "record with cost_usd=Some(0.0) should be re-priced"
+        );
+
+        // Positive cost record kept original value
+        assert_eq!(
+            records[1].cost_usd,
+            Some(99.0),
+            "record with positive cost should not be re-priced"
+        );
+
+        // None record got priced
+        assert_eq!(
+            records[2].cost_usd,
+            Some(expected_cost),
+            "record with cost_usd=None should be priced"
+        );
     }
 }

--- a/src/source/claude_code.rs
+++ b/src/source/claude_code.rs
@@ -102,22 +102,30 @@ impl super::Source for ClaudeCodeSource {
         let reader = BufReader::with_capacity(64 * 1024, file);
         let session_id = timestamp::extract_session_id(path);
 
-        let mut error_logged = false;
+        let mut io_errors = 0u64;
+        let mut json_errors = 0u64;
         let entries = reader
             .lines()
-            .map_while(std::result::Result::ok)
-            .filter(|line| line.contains("\"assistant\""))
-            .filter_map(|line| match serde_json::from_str::<ClaudeLine>(&line) {
-                Ok(parsed) => Some(parsed),
+            .filter_map(|r| match r {
+                Ok(line) => Some(line),
                 Err(e) => {
-                    if !error_logged {
+                    if io_errors == 0 {
                         eprintln!(
-                            "[tokemon] Warning: skipped malformed JSON in {}: {}",
+                            "[tokemon] Warning: I/O error reading {}: {}",
                             path.display(),
                             e
                         );
-                        error_logged = true;
                     }
+                    io_errors += 1;
+                    None
+                }
+            })
+            .filter(|line| line.contains("\"assistant\""))
+            .filter_map(|line| {
+                if let Ok(parsed) = serde_json::from_str::<ClaudeLine>(&line) {
+                    Some(parsed)
+                } else {
+                    json_errors += 1;
                     None
                 }
             })
@@ -162,6 +170,19 @@ impl super::Source for ClaudeCodeSource {
                 })
             })
             .collect();
+
+        if io_errors > 0 {
+            eprintln!(
+                "[tokemon] Warning: skipped {io_errors} lines in {} due to I/O errors",
+                path.display()
+            );
+        }
+        if json_errors > 0 {
+            eprintln!(
+                "[tokemon] Warning: skipped {json_errors} malformed JSON lines in {}",
+                path.display()
+            );
+        }
 
         Ok(entries)
     }

--- a/src/source/jsonl_source.rs
+++ b/src/source/jsonl_source.rs
@@ -101,22 +101,30 @@ impl<C: JsonlSourceConfig> super::Source for JsonlSource<C> {
         let reader = BufReader::with_capacity(64 * 1024, file);
         let session_id = timestamp::extract_session_id(path);
 
-        let mut error_logged = false;
+        let mut io_errors = 0u64;
+        let mut json_errors = 0u64;
         let entries = reader
             .lines()
-            .map_while(std::result::Result::ok)
-            .filter(|line| line.contains("\"assistant\"") || line.contains("\"response\""))
-            .filter_map(|line| match serde_json::from_str::<JsonlLine>(&line) {
-                Ok(parsed) => Some(parsed),
+            .filter_map(|r| match r {
+                Ok(line) => Some(line),
                 Err(e) => {
-                    if !error_logged {
+                    if io_errors == 0 {
                         eprintln!(
-                            "[tokemon] Warning: skipped malformed JSON in {}: {}",
+                            "[tokemon] Warning: I/O error reading {}: {}",
                             path.display(),
                             e
                         );
-                        error_logged = true;
                     }
+                    io_errors += 1;
+                    None
+                }
+            })
+            .filter(|line| line.contains("\"assistant\"") || line.contains("\"response\""))
+            .filter_map(|line| {
+                if let Ok(parsed) = serde_json::from_str::<JsonlLine>(&line) {
+                    Some(parsed)
+                } else {
+                    json_errors += 1;
                     None
                 }
             })
@@ -160,6 +168,19 @@ impl<C: JsonlSourceConfig> super::Source for JsonlSource<C> {
                 })
             })
             .collect();
+
+        if io_errors > 0 {
+            eprintln!(
+                "[tokemon] Warning: skipped {io_errors} lines in {} due to I/O errors",
+                path.display()
+            );
+        }
+        if json_errors > 0 {
+            eprintln!(
+                "[tokemon] Warning: skipped {json_errors} malformed JSON lines in {}",
+                path.display()
+            );
+        }
 
         Ok(entries)
     }

--- a/src/source/pi_agent.rs
+++ b/src/source/pi_agent.rs
@@ -76,22 +76,30 @@ impl super::Source for PiAgentSource {
         let reader = BufReader::with_capacity(64 * 1024, file);
         let session_id = timestamp::extract_session_id(path);
 
-        let mut error_logged = false;
+        let mut io_errors = 0u64;
+        let mut json_errors = 0u64;
         let entries = reader
             .lines()
-            .map_while(std::result::Result::ok)
-            .filter(|line| line.contains("\"message\"") && line.contains("\"assistant\""))
-            .filter_map(|line| match serde_json::from_str::<PiLine>(&line) {
-                Ok(parsed) => Some(parsed),
+            .filter_map(|r| match r {
+                Ok(line) => Some(line),
                 Err(e) => {
-                    if !error_logged {
+                    if io_errors == 0 {
                         eprintln!(
-                            "[tokemon] Warning: skipped malformed JSON in {}: {}",
+                            "[tokemon] Warning: I/O error reading {}: {}",
                             path.display(),
                             e
                         );
-                        error_logged = true;
                     }
+                    io_errors += 1;
+                    None
+                }
+            })
+            .filter(|line| line.contains("\"message\"") && line.contains("\"assistant\""))
+            .filter_map(|line| {
+                if let Ok(parsed) = serde_json::from_str::<PiLine>(&line) {
+                    Some(parsed)
+                } else {
+                    json_errors += 1;
                     None
                 }
             })


### PR DESCRIPTION
Two targeted fixes from the latest desloppify pass:

- Records with cost_usd of 0.0 (e.g. from OpenCode storing cost: 0 for models it can't price) are no longer permanently locked at $0. The pricing engine now treats zero-cost entries as unpriced and recalculates them against the latest pricing data.
- Replaced map_while(Result::ok) with filter_map and error counters in claude_code.rs, pi_agent.rs, and jsonl_source.rs. A single I/O error no longer silently truncates the rest of the file. Added skip counter to mark_preserved in cache.rs for row-level errors.