### PR TITLE
feat(tui): add mouse navigation support

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,8 @@ use std::time::Instant;
 
 use crate::timestamp;
 use chrono::{Duration, NaiveDate, Utc};
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
+use ratatui::layout::Rect;
 
 use crate::config::Config;
 use crate::render::{self, format_tokens_short};
@@ -13,12 +14,16 @@ use crate::{cache, cost, dedup, rollup};
 
 use super::diff::{self, RowKey};
 use super::event::Event;
+use super::views::dashboard::{self, MouseAction};
 
 /// Duration (in seconds) for the per-cell highlight fade animation.
 const HIGHLIGHT_DURATION_SECS: f64 = 1.5;
 
 /// Duration (in seconds) for warnings to remain visible in the status bar.
 const WARNING_DISPLAY_SECS: f64 = 5.0;
+
+/// Number of rows moved by one mouse-wheel event.
+const MOUSE_SCROLL_ROWS: u16 = 3;
 
 // ── View scope ────────────────────────────────────────────────────────────
 
@@ -317,10 +322,15 @@ impl App {
     }
 
     /// Handle an incoming event. Returns `true` if the UI needs a redraw.
-    pub fn handle_event(&mut self, event: &Event) -> bool {
+    pub fn handle_event(&mut self, event: &Event, terminal_area: Rect) -> bool {
         match event {
             Event::Key(key) => {
                 let changed = self.handle_key(*key);
+                self.dirty |= changed;
+                changed
+            }
+            Event::Mouse(mouse) => {
+                let changed = self.handle_mouse(*mouse, terminal_area);
                 self.dirty |= changed;
                 changed
             }
@@ -363,6 +373,19 @@ impl App {
                 true
             }
             Event::Render => false,
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent, terminal_area: Rect) -> bool {
+        if self.show_settings || self.show_help || self.filter_active {
+            return false;
+        }
+
+        match dashboard::mouse_action(terminal_area, mouse) {
+            Some(MouseAction::SelectScope(scope)) => self.select_scope(scope),
+            Some(MouseAction::ScrollUp) => self.scroll_up(MOUSE_SCROLL_ROWS),
+            Some(MouseAction::ScrollDown) => self.scroll_down(MOUSE_SCROLL_ROWS),
+            None => false,
         }
     }
 
@@ -422,26 +445,10 @@ impl App {
                 self.filter_text = self.applied_filter.clone();
                 true
             }
-            KeyCode::Char('t') => {
-                self.scope = Scope::Today;
-                self.reset_view_state();
-                true
-            }
-            KeyCode::Char('w') => {
-                self.scope = Scope::Week;
-                self.reset_view_state();
-                true
-            }
-            KeyCode::Char('m') => {
-                self.scope = Scope::Month;
-                self.reset_view_state();
-                true
-            }
-            KeyCode::Char('a') => {
-                self.scope = Scope::AllTime;
-                self.reset_view_state();
-                true
-            }
+            KeyCode::Char('t') => self.select_scope(Scope::Today),
+            KeyCode::Char('w') => self.select_scope(Scope::Week),
+            KeyCode::Char('m') => self.select_scope(Scope::Month),
+            KeyCode::Char('a') => self.select_scope(Scope::AllTime),
             KeyCode::Char('s') => {
                 self.sort_order = self.sort_order.next();
                 self.reset_view_state();
@@ -460,15 +467,8 @@ impl App {
                 self.recompute_detail();
                 true
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                let max = self.detail_models.len().saturating_sub(1) as u16;
-                self.scroll_offset = self.scroll_offset.saturating_add(1).min(max);
-                true
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.scroll_offset = self.scroll_offset.saturating_sub(1);
-                true
-            }
+            KeyCode::Char('j') | KeyCode::Down => self.scroll_down(1),
+            KeyCode::Char('k') | KeyCode::Up => self.scroll_up(1),
             KeyCode::Left => {
                 let new_scope = match self.scope {
                     Scope::Today | Scope::Week => Scope::Today,
@@ -498,6 +498,33 @@ impl App {
                 }
             }
             _ => false,
+        }
+    }
+
+    fn select_scope(&mut self, scope: Scope) -> bool {
+        self.scope = scope;
+        self.reset_view_state();
+        true
+    }
+
+    fn scroll_down(&mut self, rows: u16) -> bool {
+        let max = self.detail_models.len().saturating_sub(1) as u16;
+        let next = self.scroll_offset.saturating_add(rows).min(max);
+        if next == self.scroll_offset {
+            false
+        } else {
+            self.scroll_offset = next;
+            true
+        }
+    }
+
+    fn scroll_up(&mut self, rows: u16) -> bool {
+        let next = self.scroll_offset.saturating_sub(rows);
+        if next == self.scroll_offset {
+            false
+        } else {
+            self.scroll_offset = next;
+            true
         }
     }
 

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use crossterm::event::{Event as CrosstermEvent, EventStream, KeyEventKind};
+use crossterm::event::{
+    Event as CrosstermEvent, EventStream, KeyEventKind, MouseButton, MouseEventKind,
+};
 use futures_lite::StreamExt;
 use tokio::sync::mpsc;
 
@@ -9,6 +11,8 @@ use tokio::sync::mpsc;
 pub enum Event {
     /// A key was pressed.
     Key(crossterm::event::KeyEvent),
+    /// A mouse button was pressed or the wheel was scrolled.
+    Mouse(crossterm::event::MouseEvent),
     /// Terminal was resized (values used by ratatui's `frame.area()` implicitly).
     #[allow(dead_code)]
     Resize(u16, u16),
@@ -75,13 +79,7 @@ impl EventHandler {
                     // Crossterm terminal events (key presses, resize, etc.)
                     maybe_event = crossterm_events.next() => {
                         match maybe_event {
-                            Some(Ok(evt)) => match evt {
-                                CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => {
-                                    Some(Event::Key(key))
-                                }
-                                CrosstermEvent::Resize(w, h) => Some(Event::Resize(w, h)),
-                                _ => None,
-                            },
+                            Some(Ok(evt)) => map_crossterm_event(&evt),
                             // Stream ended or error — stop the loop
                             Some(Err(_)) | None => break,
                         }
@@ -114,5 +112,71 @@ impl EventHandler {
     #[allow(dead_code)]
     pub fn try_next(&mut self) -> Result<Event, mpsc::error::TryRecvError> {
         self.rx.try_recv()
+    }
+}
+
+fn map_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
+    match event {
+        CrosstermEvent::Key(key) if key.kind == KeyEventKind::Press => Some(Event::Key(*key)),
+        CrosstermEvent::Mouse(mouse)
+            if matches!(
+                mouse.kind,
+                MouseEventKind::Down(MouseButton::Left)
+                    | MouseEventKind::ScrollUp
+                    | MouseEventKind::ScrollDown
+            ) =>
+        {
+            Some(Event::Mouse(*mouse))
+        }
+        CrosstermEvent::Resize(width, height) => Some(Event::Resize(*width, *height)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
+        MouseEventKind,
+    };
+
+    use super::{map_crossterm_event, CrosstermEvent, Event};
+
+    #[test]
+    fn routes_mouse_events() {
+        let mouse = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 12,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        let mapped = map_crossterm_event(&CrosstermEvent::Mouse(mouse));
+
+        assert!(matches!(mapped, Some(Event::Mouse(event)) if event == mouse));
+    }
+
+    #[test]
+    fn ignores_key_release_events() {
+        let key = KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Release,
+            state: KeyEventState::NONE,
+        };
+
+        assert!(map_crossterm_event(&CrosstermEvent::Key(key)).is_none());
+    }
+
+    #[test]
+    fn ignores_mouse_motion() {
+        let mouse = MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 12,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        assert!(map_crossterm_event(&CrosstermEvent::Mouse(mouse)).is_none());
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -11,6 +11,8 @@ mod widgets;
 
 use std::time::Duration;
 
+use ratatui::layout::Rect;
+
 use crate::config::Config;
 use app::{App, Scope};
 use event::{Event, EventHandler};
@@ -63,6 +65,7 @@ async fn run_async(
     offline: bool,
 ) -> anyhow::Result<()> {
     let mut terminal = terminal::init()?;
+    let mut terminal_area = Rect::from(terminal.size()?);
     let mut app = App::new(config, scope, offline);
 
     let mut events = EventHandler::new(
@@ -87,7 +90,10 @@ async fn run_async(
             match &event {
                 Event::Render => {} // render ticks don't mark state dirty
                 other => {
-                    app.handle_event(other);
+                    if let Event::Resize(width, height) = other {
+                        terminal_area = Rect::new(0, 0, *width, *height);
+                    }
+                    app.handle_event(other, terminal_area);
                 }
             }
 

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -1,4 +1,5 @@
-use ratatui::layout::{Constraint, Layout};
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::Block;
 use ratatui::Frame;
 
@@ -6,6 +7,21 @@ use crate::tui::app::App;
 use crate::tui::theme;
 use crate::tui::views::{help, settings};
 use crate::tui::widgets::{header, status_bar, summary_cards, usage_table};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MouseAction {
+    SelectScope(crate::tui::app::Scope),
+    ScrollUp,
+    ScrollDown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DashboardLayout {
+    header: Rect,
+    summary_cards: Option<Rect>,
+    pub usage_table: Rect,
+    status_bar: Rect,
+}
 
 /// Render the complete dashboard view.
 ///
@@ -24,46 +40,21 @@ pub fn render(frame: &mut Frame, app: &App) {
     let bg = Block::default().style(theme::text());
     frame.render_widget(bg, area);
 
-    // Determine card height based on terminal height
-    let card_height = if area.height >= 30 {
-        7
-    } else if area.height >= 20 {
-        5
-    } else {
-        0 // Skip cards on very small terminals
-    };
-
-    let mut constraints = vec![
-        Constraint::Length(1), // header
-    ];
-
-    if card_height > 0 {
-        constraints.push(Constraint::Length(card_height)); // summary cards
-    }
-
-    constraints.push(Constraint::Min(5)); // usage table
-    constraints.push(Constraint::Length(1)); // status bar
-
-    let layout = Layout::vertical(constraints).split(area);
-
-    let mut idx = 0;
+    let layout = dashboard_layout(area);
 
     // Header
-    header::render(frame, layout[idx], app);
-    idx += 1;
+    header::render(frame, layout.header, app);
 
     // Summary cards (if space)
-    if card_height > 0 {
-        summary_cards::render(frame, layout[idx], app);
-        idx += 1;
+    if let Some(cards_area) = layout.summary_cards {
+        summary_cards::render(frame, cards_area, app);
     }
 
     // Usage table
-    usage_table::render(frame, layout[idx], app);
-    idx += 1;
+    usage_table::render(frame, layout.usage_table, app);
 
     // Status bar
-    status_bar::render(frame, layout[idx], app);
+    status_bar::render(frame, layout.status_bar, app);
 
     // Overlays (rendered on top of everything)
     if app.show_help {
@@ -71,5 +62,151 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if app.show_settings {
         settings::render(frame, app);
+    }
+}
+
+/// Calculate the dashboard regions used by both rendering and mouse hit-testing.
+#[must_use]
+pub(crate) fn dashboard_layout(area: Rect) -> DashboardLayout {
+    let card_height = if area.height >= 30 {
+        7
+    } else if area.height >= 20 {
+        5
+    } else {
+        0
+    };
+
+    let mut constraints = vec![Constraint::Length(1)];
+    if card_height > 0 {
+        constraints.push(Constraint::Length(card_height));
+    }
+    constraints.push(Constraint::Min(5));
+    constraints.push(Constraint::Length(1));
+
+    let areas = Layout::vertical(constraints).split(area);
+    let mut index = 0;
+    let header = areas[index];
+    index += 1;
+    let summary_cards = if card_height > 0 {
+        let cards = areas[index];
+        index += 1;
+        Some(cards)
+    } else {
+        None
+    };
+
+    DashboardLayout {
+        header,
+        summary_cards,
+        usage_table: areas[index],
+        status_bar: areas[index + 1],
+    }
+}
+
+/// Translate a raw mouse event into a dashboard action.
+#[must_use]
+pub(crate) fn mouse_action(area: Rect, event: MouseEvent) -> Option<MouseAction> {
+    let layout = dashboard_layout(area);
+
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => layout
+            .summary_cards
+            .and_then(|cards| summary_cards::scope_at(cards, event.column, event.row))
+            .map(MouseAction::SelectScope),
+        MouseEventKind::ScrollUp if contains(layout.usage_table, event.column, event.row) => {
+            Some(MouseAction::ScrollUp)
+        }
+        MouseEventKind::ScrollDown if contains(layout.usage_table, event.column, event.row) => {
+            Some(MouseAction::ScrollDown)
+        }
+        _ => None,
+    }
+}
+
+fn contains(area: Rect, column: u16, row: u16) -> bool {
+    column >= area.x
+        && column < area.x.saturating_add(area.width)
+        && row >= area.y
+        && row < area.y.saturating_add(area.height)
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::layout::Rect;
+
+    use super::{dashboard_layout, mouse_action, MouseAction};
+    use crate::tui::app::Scope;
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn dashboard_layout_uses_responsive_card_heights() {
+        let large = dashboard_layout(Rect::new(0, 0, 80, 30));
+        assert_eq!(large.summary_cards, Some(Rect::new(0, 1, 80, 7)));
+        assert_eq!(large.usage_table, Rect::new(0, 8, 80, 21));
+
+        let medium = dashboard_layout(Rect::new(0, 0, 80, 20));
+        assert_eq!(medium.summary_cards, Some(Rect::new(0, 1, 80, 5)));
+        assert_eq!(medium.usage_table, Rect::new(0, 6, 80, 13));
+
+        let small = dashboard_layout(Rect::new(0, 0, 80, 19));
+        assert_eq!(small.summary_cards, None);
+        assert_eq!(small.usage_table, Rect::new(0, 1, 80, 17));
+    }
+
+    #[test]
+    fn left_click_on_card_selects_its_scope() {
+        let area = Rect::new(0, 0, 80, 30);
+
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::Down(MouseButton::Left), 45, 2)),
+            Some(MouseAction::SelectScope(Scope::Month))
+        );
+    }
+
+    #[test]
+    fn card_click_is_ignored_when_cards_are_not_rendered() {
+        let area = Rect::new(0, 0, 80, 19);
+
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::Down(MouseButton::Left), 5, 2)),
+            None
+        );
+    }
+
+    #[test]
+    fn wheel_only_scrolls_over_usage_table() {
+        let area = Rect::new(0, 0, 80, 30);
+
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::ScrollDown, 10, 10)),
+            Some(MouseAction::ScrollDown)
+        );
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::ScrollUp, 10, 2)),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_other_mouse_events() {
+        let area = Rect::new(0, 0, 80, 30);
+
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::Moved, 10, 10)),
+            None
+        );
+        assert_eq!(
+            mouse_action(area, mouse(MouseEventKind::Down(MouseButton::Right), 10, 2)),
+            None
+        );
     }
 }

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -41,6 +41,7 @@ pub fn render(frame: &mut Frame) {
         ("/", "Filter by model/provider"),
         ("j / ↓", "Scroll table down"),
         ("k / ↑", "Scroll table up"),
+        ("Mouse", "Click scope cards / scroll table"),
         ("S", "Open settings editor"),
         ("?", "Toggle this help"),
         ("q / Esc", "Quit (or clear filter)"),

--- a/src/tui/widgets/summary_cards.rs
+++ b/src/tui/widgets/summary_cards.rs
@@ -15,23 +15,8 @@ use crate::tui::theme;
 /// - Token count (secondary)
 /// - Sparkline (trend)
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
-    // Split into 4 equal columns
-    let [c1, c2, c3, c4] = Layout::horizontal([
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-    ])
-    .areas(area);
-
-    let scoped = [
-        (Scope::Today, c1),
-        (Scope::Week, c2),
-        (Scope::Month, c3),
-        (Scope::AllTime, c4),
-    ];
     let show_sparklines = app.config.show_sparklines;
-    for (i, &(scope, card_area)) in scoped.iter().enumerate() {
+    for (i, (scope, card_area)) in card_areas(area).into_iter().enumerate() {
         render_card(
             frame,
             card_area,
@@ -40,6 +25,40 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             show_sparklines,
         );
     }
+}
+
+/// Return the scope card rectangles in their rendered order.
+#[must_use]
+pub(crate) fn card_areas(area: Rect) -> [(Scope, Rect); 4] {
+    let [today, week, month, all_time] = Layout::horizontal([
+        Constraint::Ratio(1, 4),
+        Constraint::Ratio(1, 4),
+        Constraint::Ratio(1, 4),
+        Constraint::Ratio(1, 4),
+    ])
+    .areas(area);
+
+    [
+        (Scope::Today, today),
+        (Scope::Week, week),
+        (Scope::Month, month),
+        (Scope::AllTime, all_time),
+    ]
+}
+
+/// Return the scope card at a terminal coordinate, if any.
+#[must_use]
+pub(crate) fn scope_at(area: Rect, column: u16, row: u16) -> Option<Scope> {
+    card_areas(area)
+        .into_iter()
+        .find_map(|(scope, card_area)| contains(card_area, column, row).then_some(scope))
+}
+
+fn contains(area: Rect, column: u16, row: u16) -> bool {
+    column >= area.x
+        && column < area.x.saturating_add(area.width)
+        && row >= area.y
+        && row < area.y.saturating_add(area.height)
 }
 
 fn render_card(
@@ -144,5 +163,36 @@ fn render_card(
                 .bg(theme::SURFACE),
         );
         frame.render_widget(sparkline, card_areas[3]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::layout::Rect;
+
+    use super::{card_areas, scope_at};
+    use crate::tui::app::Scope;
+
+    #[test]
+    fn splits_card_area_into_scope_order() {
+        let area = Rect::new(4, 2, 80, 7);
+        let cards = card_areas(area);
+
+        assert_eq!(cards[0], (Scope::Today, Rect::new(4, 2, 20, 7)));
+        assert_eq!(cards[1], (Scope::Week, Rect::new(24, 2, 20, 7)));
+        assert_eq!(cards[2], (Scope::Month, Rect::new(44, 2, 20, 7)));
+        assert_eq!(cards[3], (Scope::AllTime, Rect::new(64, 2, 20, 7)));
+    }
+
+    #[test]
+    fn hit_tests_card_boundaries() {
+        let area = Rect::new(0, 1, 80, 7);
+
+        assert_eq!(scope_at(area, 0, 1), Some(Scope::Today));
+        assert_eq!(scope_at(area, 19, 7), Some(Scope::Today));
+        assert_eq!(scope_at(area, 20, 1), Some(Scope::Week));
+        assert_eq!(scope_at(area, 79, 7), Some(Scope::AllTime));
+        assert_eq!(scope_at(area, 80, 7), None);
+        assert_eq!(scope_at(area, 10, 8), None);
     }
 }


### PR DESCRIPTION
Fixes #12.

## What changed

- route actionable mouse events into the TUI
- click Today, This Week, This Month, or All Time cards to select scope
- scroll the usage table with the mouse wheel in three-row steps
- share dashboard and card geometry between rendering and hit-testing
- block mouse click-through while help, settings, or filter input is active
- document mouse controls in help

## Validation

- `cargo fmt -- --check`
- `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions`
- `cargo test`
- `git diff --check`