### PR TITLE
feat: toggle summary cards in top view

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -450,12 +450,13 @@ impl App {
         }
 
         let hover_changed = self.set_hover(dashboard::hover_target(terminal_area, self, mouse));
-        let action_changed = match dashboard::mouse_action(terminal_area, self.card_visibility, mouse) {
-            Some(MouseAction::SelectScope(scope)) => self.select_scope(scope),
-            Some(MouseAction::ScrollUp) => self.scroll_up(MOUSE_SCROLL_ROWS),
-            Some(MouseAction::ScrollDown) => self.scroll_down(MOUSE_SCROLL_ROWS),
-            None => false,
-        };
+        let action_changed =
+            match dashboard::mouse_action(terminal_area, self.card_visibility, mouse) {
+                Some(MouseAction::SelectScope(scope)) => self.select_scope(scope),
+                Some(MouseAction::ScrollUp) => self.scroll_up(MOUSE_SCROLL_ROWS),
+                Some(MouseAction::ScrollDown) => self.scroll_down(MOUSE_SCROLL_ROWS),
+                None => false,
+            };
         hover_changed || action_changed
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -32,6 +32,8 @@ pub enum Scope {
 }
 
 impl Scope {
+    pub const ALL: [Self; 4] = [Self::Today, Self::Week, Self::Month, Self::AllTime];
+
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
@@ -52,11 +54,66 @@ impl Scope {
             Self::AllTime => NaiveDate::from_ymd_opt(2000, 1, 1).unwrap(),
         }
     }
+
+    #[must_use]
+    pub(crate) const fn card_index(self) -> usize {
+        match self {
+            Self::Today => 0,
+            Self::Week => 1,
+            Self::Month => 2,
+            Self::AllTime => 3,
+        }
+    }
+
+    #[must_use]
+    const fn from_card_toggle_key(key: char) -> Option<Self> {
+        match key {
+            'T' => Some(Self::Today),
+            'W' => Some(Self::Week),
+            'M' => Some(Self::Month),
+            'A' => Some(Self::AllTime),
+            _ => None,
+        }
+    }
 }
 
 // ── Summary card data ─────────────────────────────────────────────────────
 
-/// Data for one summary card (Today / This Week / This Month).
+/// Session-only visibility state for the four summary cards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SummaryCardVisibility {
+    visible: [bool; 4],
+}
+
+impl Default for SummaryCardVisibility {
+    fn default() -> Self {
+        Self { visible: [true; 4] }
+    }
+}
+
+impl SummaryCardVisibility {
+    pub const fn toggle(&mut self, scope: Scope) {
+        let index = scope.card_index();
+        self.visible[index] = !self.visible[index];
+    }
+
+    #[must_use]
+    pub const fn is_visible(self, scope: Scope) -> bool {
+        self.visible[scope.card_index()]
+    }
+
+    #[must_use]
+    pub fn any_visible(self) -> bool {
+        self.visible.iter().any(|visible| *visible)
+    }
+
+    #[must_use]
+    pub fn visible_count(self) -> usize {
+        self.visible.iter().filter(|visible| **visible).count()
+    }
+}
+
+/// Data for one summary card (Today / This Week / This Month / All Time).
 #[derive(Debug, Clone)]
 pub struct CardData {
     pub label: &'static str,
@@ -147,6 +204,8 @@ pub struct App {
     pub show_history: bool,
     /// Summary cards: Today, This Week, This Month, All Time.
     pub cards: [CardData; 4],
+    /// Which summary cards are visible for this TUI session.
+    pub card_visibility: SummaryCardVisibility,
     /// Detail table rows for the selected scope.
     pub detail_models: Vec<ModelUsage>,
     /// Detail totals.
@@ -254,6 +313,7 @@ impl App {
                     trend: 0,
                 },
             ],
+            card_visibility: SummaryCardVisibility::default(),
             detail_models: Vec::new(),
             detail_total_cost: 0.0,
             detail_total_tokens: 0,
@@ -394,6 +454,13 @@ impl App {
         // Filter input mode
         if self.filter_active {
             return self.handle_filter_key(key);
+        }
+
+        if let KeyCode::Char(c) = key.code {
+            if let Some(scope) = Scope::from_card_toggle_key(c) {
+                self.card_visibility.toggle(scope);
+                return true;
+            }
         }
 
         match key.code {
@@ -1027,4 +1094,53 @@ fn load_records_from_cache(pricing: Option<&cost::PricingEngine>) -> Vec<Record>
     // Dedup is handled inside load_entries_filtered.
     entries.sort_by_key(|e| e.timestamp);
     entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Scope, SummaryCardVisibility};
+
+    #[test]
+    fn summary_cards_start_visible_and_toggle_independently() {
+        let mut visibility = SummaryCardVisibility::default();
+        assert_eq!(visibility.visible_count(), 4);
+        assert!(Scope::ALL
+            .into_iter()
+            .all(|scope| visibility.is_visible(scope)));
+
+        visibility.toggle(Scope::Week);
+        visibility.toggle(Scope::AllTime);
+
+        assert!(visibility.is_visible(Scope::Today));
+        assert!(!visibility.is_visible(Scope::Week));
+        assert!(visibility.is_visible(Scope::Month));
+        assert!(!visibility.is_visible(Scope::AllTime));
+        assert_eq!(visibility.visible_count(), 2);
+
+        visibility.toggle(Scope::Week);
+        assert!(visibility.is_visible(Scope::Week));
+        assert_eq!(visibility.visible_count(), 3);
+    }
+
+    #[test]
+    fn all_summary_cards_can_be_hidden() {
+        let mut visibility = SummaryCardVisibility::default();
+        for scope in Scope::ALL {
+            visibility.toggle(scope);
+        }
+
+        assert!(!visibility.any_visible());
+        assert_eq!(visibility.visible_count(), 0);
+    }
+
+    #[test]
+    fn only_uppercase_scope_keys_toggle_cards() {
+        assert_eq!(Scope::from_card_toggle_key('T'), Some(Scope::Today));
+        assert_eq!(Scope::from_card_toggle_key('W'), Some(Scope::Week));
+        assert_eq!(Scope::from_card_toggle_key('M'), Some(Scope::Month));
+        assert_eq!(Scope::from_card_toggle_key('A'), Some(Scope::AllTime));
+        assert_eq!(Scope::from_card_toggle_key('t'), None);
+        assert_eq!(Scope::from_card_toggle_key('w'), None);
+        assert_eq!(Scope::from_card_toggle_key('x'), None);
+    }
 }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -132,7 +132,9 @@ pub(crate) fn hover_target(area: Rect, app: &App, event: MouseEvent) -> Option<H
 
     layout
         .summary_cards
-        .and_then(|cards| summary_cards::scope_at(cards, app.card_visibility, event.column, event.row))
+        .and_then(|cards| {
+            summary_cards::scope_at(cards, app.card_visibility, event.column, event.row)
+        })
         .map(HoverTarget::Card)
         .or_else(|| {
             usage_table::row_at(layout.usage_table, app, event.column, event.row)
@@ -216,7 +218,11 @@ mod tests {
             hidden.toggle(scope);
         }
         assert_eq!(
-            mouse_action(area, hidden, mouse(MouseEventKind::Down(MouseButton::Left), 5, 2)),
+            mouse_action(
+                area,
+                hidden,
+                mouse(MouseEventKind::Down(MouseButton::Left), 5, 2)
+            ),
             None
         );
     }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -24,14 +24,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     let bg = Block::default().style(theme::text());
     frame.render_widget(bg, area);
 
-    // Determine card height based on terminal height
-    let card_height = if area.height >= 30 {
-        7
-    } else if area.height >= 20 {
-        5
-    } else {
-        0 // Skip cards on very small terminals
-    };
+    let card_height = summary_card_height(area.height, app.card_visibility.any_visible());
 
     let mut constraints = vec![
         Constraint::Length(1), // header
@@ -71,5 +64,36 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
     if app.show_settings {
         settings::render(frame, app);
+    }
+}
+
+#[must_use]
+const fn summary_card_height(terminal_height: u16, has_visible_cards: bool) -> u16 {
+    if !has_visible_cards {
+        0
+    } else if terminal_height >= 30 {
+        7
+    } else if terminal_height >= 20 {
+        5
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::summary_card_height;
+
+    #[test]
+    fn hidden_cards_reclaim_the_layout_space() {
+        assert_eq!(summary_card_height(40, false), 0);
+        assert_eq!(summary_card_height(25, false), 0);
+    }
+
+    #[test]
+    fn visible_cards_keep_responsive_height() {
+        assert_eq!(summary_card_height(30, true), 7);
+        assert_eq!(summary_card_height(20, true), 5);
+        assert_eq!(summary_card_height(19, true), 0);
     }
 }

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -155,7 +155,7 @@ mod tests {
     use ratatui::layout::Rect;
 
     use super::{dashboard_layout, mouse_action, summary_card_height, MouseAction};
-    use crate::tui::app::Scope;
+    use crate::tui::app::{Scope, SummaryCardVisibility};
 
     fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
         MouseEvent {

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -34,6 +34,7 @@ pub fn render(frame: &mut Frame) {
 
     let bindings = vec![
         ("t / w / m / a", "Switch scope (Today/Week/Month/All)"),
+        ("T / W / M / A", "Toggle matching summary card only"),
         ("← / →", "Cycle scope left/right"),
         ("g", "Cycle group-by (model/client/both)"),
         ("h", "Toggle historical periods"),

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -53,6 +53,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let group_label = format!("group:{}", app.group_by.label());
     let bindings: Vec<(&str, &str)> = vec![
         ("t/w/m/a", "scope"),
+        ("T/W/M/A", "cards"),
         ("g", &group_label),
         ("h", "history"),
         ("s", &sort_label),

--- a/src/tui/widgets/summary_cards.rs
+++ b/src/tui/widgets/summary_cards.rs
@@ -22,31 +22,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     }
 }
 
-/// Return all four scope card rectangles in their default rendered order.
-#[must_use]
-pub(crate) fn card_areas(area: Rect) -> [(Scope, Rect); 4] {
-    let [today, week, month, all_time] = Layout::horizontal([
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-    ])
-    .areas(area);
-
-    [
-        (Scope::Today, today),
-        (Scope::Week, week),
-        (Scope::Month, month),
-        (Scope::AllTime, all_time),
-    ]
-}
-
 fn visible_card_areas(area: Rect, visibility: SummaryCardVisibility) -> Vec<(Scope, Rect)> {
     let visible_scopes: Vec<Scope> = Scope::ALL
         .into_iter()
         .filter(|scope| visibility.is_visible(*scope))
         .collect();
-    let count = visible_scopes.len();
+    let count = visibility.visible_count();
     if count == 0 {
         return Vec::new();
     }
@@ -188,13 +169,13 @@ fn render_card(
 mod tests {
     use ratatui::layout::Rect;
 
-    use super::{card_areas, scope_at};
+    use super::{scope_at, visible_card_areas};
     use crate::tui::app::{Scope, SummaryCardVisibility};
 
     #[test]
     fn splits_card_area_into_scope_order() {
         let area = Rect::new(4, 2, 80, 7);
-        let cards = card_areas(area);
+        let cards = visible_card_areas(area, SummaryCardVisibility::default());
 
         assert_eq!(cards[0], (Scope::Today, Rect::new(4, 2, 20, 7)));
         assert_eq!(cards[1], (Scope::Week, Rect::new(24, 2, 20, 7)));

--- a/src/tui/widgets/summary_cards.rs
+++ b/src/tui/widgets/summary_cards.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 use crate::tui::app::{App, Scope};
 use crate::tui::theme;
 
-/// Render the four summary cards: Today, This Week, This Month, All Time.
+/// Render the visible summary cards: Today, This Week, This Month, All Time.
 ///
 /// Each card shows:
 /// - Label (highlighted if it matches the active scope)
@@ -15,27 +15,23 @@ use crate::tui::theme;
 /// - Token count (secondary)
 /// - Sparkline (trend)
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
-    // Split into 4 equal columns
-    let [c1, c2, c3, c4] = Layout::horizontal([
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-        Constraint::Ratio(1, 4),
-    ])
-    .areas(area);
+    let visible_count = app.card_visibility.visible_count();
+    if visible_count == 0 {
+        return;
+    }
 
-    let scoped = [
-        (Scope::Today, c1),
-        (Scope::Week, c2),
-        (Scope::Month, c3),
-        (Scope::AllTime, c4),
-    ];
+    let visible_scopes: Vec<Scope> = Scope::ALL
+        .into_iter()
+        .filter(|scope| app.card_visibility.is_visible(*scope))
+        .collect();
+    let constraints = vec![Constraint::Ratio(1, visible_count as u32); visible_count];
+    let card_areas = Layout::horizontal(constraints).split(area);
     let show_sparklines = app.config.show_sparklines;
-    for (i, &(scope, card_area)) in scoped.iter().enumerate() {
+    for (scope, card_area) in visible_scopes.into_iter().zip(card_areas.iter().copied()) {
         render_card(
             frame,
             card_area,
-            &app.cards[i],
+            &app.cards[scope.card_index()],
             scope == app.scope,
             show_sparklines,
         );

--- a/src/tui/widgets/summary_cards.rs
+++ b/src/tui/widgets/summary_cards.rs
@@ -220,6 +220,9 @@ mod tests {
         let mut visibility = SummaryCardVisibility::default();
         visibility.toggle(Scope::Today);
 
-        assert_eq!(scope_at(Rect::new(0, 1, 60, 7), visibility, 1, 1), Some(Scope::Week));
+        assert_eq!(
+            scope_at(Rect::new(0, 1, 60, 7), visibility, 1, 1),
+            Some(Scope::Week)
+        );
     }
 }


### PR DESCRIPTION
## What changed

- uppercase `T/W/M/A` independently toggle the matching top summary card
- lowercase `t/w/m/a` continue to select the detail scope
- visible cards reflow evenly across the available width
- hiding all four cards removes the summary row and expands the table
- card visibility is session-only and never filters detail rows, totals, or history
- add help and status-bar hints

## Validation

- `cargo fmt -- --check`
- `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions`
- `cargo test`