### PR TITLE
feat(tui): add persistent metric visibility

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -175,6 +175,7 @@ pub struct ColumnConfig {
     pub output: bool,
     pub cache_write: bool,
     pub cache_read: bool,
+    pub requests: bool,
     pub total_tokens: bool,
     pub cost: bool,
 }
@@ -214,6 +215,7 @@ impl Default for ColumnConfig {
             output: true,
             cache_write: true,
             cache_read: true,
+            requests: true,
             total_tokens: true,
             cost: true,
         }
@@ -351,12 +353,28 @@ mod tests {
         assert!(config.columns.output);
         assert!(config.columns.cache_write);
         assert!(config.columns.cache_read);
+        assert!(config.columns.requests);
         assert!(config.columns.total_tokens);
         assert!(config.columns.cost);
 
         assert!(config.budget.daily.is_none());
         assert!(config.budget.weekly.is_none());
         assert!(config.budget.monthly.is_none());
+    }
+
+    #[test]
+    fn existing_column_config_defaults_new_visibility_fields() {
+        let config: Config = toml::from_str(
+            r#"
+            [columns]
+            cost = false
+            "#,
+        )
+        .expect("existing config should deserialize");
+
+        assert!(config.columns.requests);
+        assert!(config.columns.total_tokens);
+        assert!(!config.columns.cost);
     }
 
     #[test]

--- a/src/tui/settings_state.rs
+++ b/src/tui/settings_state.rs
@@ -23,11 +23,14 @@ pub(crate) enum SettingField {
     ColClient,
     ColInput,
     ColOutput,
+    ColRequests,
+    ColTotalTokens,
+    ColCost,
 }
 
 impl SettingField {
     /// Total number of settings fields.
-    pub const COUNT: usize = 16;
+    pub const COUNT: usize = 19;
 
     /// All fields in display order.
     pub const ALL: [Self; Self::COUNT] = [
@@ -47,6 +50,9 @@ impl SettingField {
         Self::ColClient,
         Self::ColInput,
         Self::ColOutput,
+        Self::ColRequests,
+        Self::ColTotalTokens,
+        Self::ColCost,
     ];
 
     /// Display label for this field.
@@ -69,6 +75,9 @@ impl SettingField {
             Self::ColClient => "Client",
             Self::ColInput => "Input Tokens",
             Self::ColOutput => "Output Tokens",
+            Self::ColRequests => "Requests",
+            Self::ColTotalTokens => "Total Tokens",
+            Self::ColCost => "Cost",
         }
     }
 
@@ -95,6 +104,9 @@ impl SettingField {
                 | Self::ColClient
                 | Self::ColInput
                 | Self::ColOutput
+                | Self::ColRequests
+                | Self::ColTotalTokens
+                | Self::ColCost
         )
     }
 
@@ -143,6 +155,9 @@ impl SettingField {
             Self::ColClient => bool_display(config.columns.client),
             Self::ColInput => bool_display(config.columns.input),
             Self::ColOutput => bool_display(config.columns.output),
+            Self::ColRequests => bool_display(config.columns.requests),
+            Self::ColTotalTokens => bool_display(config.columns.total_tokens),
+            Self::ColCost => bool_display(config.columns.cost),
         }
     }
 
@@ -155,6 +170,9 @@ impl SettingField {
             Self::ColClient => config.columns.client = !config.columns.client,
             Self::ColInput => config.columns.input = !config.columns.input,
             Self::ColOutput => config.columns.output = !config.columns.output,
+            Self::ColRequests => config.columns.requests = !config.columns.requests,
+            Self::ColTotalTokens => config.columns.total_tokens = !config.columns.total_tokens,
+            Self::ColCost => config.columns.cost = !config.columns.cost,
             _ => {}
         }
     }
@@ -305,5 +323,36 @@ impl SettingsState {
                 self.flash_message = None;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_visibility_is_independent_from_cost_calculation() {
+        let mut config = Config::default();
+
+        SettingField::ColCost.toggle_bool(&mut config);
+        assert!(!config.columns.cost);
+        assert!(!config.no_cost);
+
+        SettingField::NoCost.toggle_bool(&mut config);
+        assert!(config.no_cost);
+        assert!(!config.columns.cost);
+    }
+
+    #[test]
+    fn metric_fields_toggle_their_persisted_columns() {
+        let mut config = Config::default();
+
+        SettingField::ColRequests.toggle_bool(&mut config);
+        SettingField::ColTotalTokens.toggle_bool(&mut config);
+        SettingField::ColCost.toggle_bool(&mut config);
+
+        assert!(!config.columns.requests);
+        assert!(!config.columns.total_tokens);
+        assert!(!config.columns.cost);
     }
 }

--- a/src/tui/widgets/usage_table.rs
+++ b/src/tui/widgets/usage_table.rs
@@ -229,6 +229,8 @@ struct ColumnSet {
     show_input: bool,
     show_output: bool,
     show_requests: bool,
+    show_total: bool,
+    show_cost: bool,
 }
 
 impl ColumnSet {
@@ -238,9 +240,11 @@ impl ColumnSet {
         Self {
             show_api: self.show_api && cfg.api_provider,
             show_client: self.show_client && cfg.client,
-            show_requests: self.show_requests,
+            show_requests: self.show_requests && cfg.requests,
             show_input: self.show_input && cfg.input,
             show_output: self.show_output && cfg.output,
+            show_total: self.show_total && cfg.total_tokens,
+            show_cost: self.show_cost && cfg.cost,
         }
     }
 
@@ -261,8 +265,12 @@ impl ColumnSet {
         if self.show_output {
             h.push("Output".to_string());
         }
-        h.push("Total".to_string());
-        h.push("Cost".to_string());
+        if self.show_total {
+            h.push("Total".to_string());
+        }
+        if self.show_cost {
+            h.push("Cost".to_string());
+        }
         h
     }
 
@@ -283,8 +291,12 @@ impl ColumnSet {
         if self.show_output {
             w.push(Constraint::Length(8));
         }
-        w.push(Constraint::Length(8)); // Total
-        w.push(Constraint::Length(10)); // Cost
+        if self.show_total {
+            w.push(Constraint::Length(8));
+        }
+        if self.show_cost {
+            w.push(Constraint::Length(10));
+        }
         w
     }
 
@@ -354,23 +366,27 @@ impl ColumnSet {
             cells.push(Cell::from(Span::styled(s, style)));
         }
 
-        let total_s = format_tokens_short(total);
-        let normal_total = if use_color {
-            base_style.fg(theme::tokens_color(total))
-        } else {
-            base_style
-        };
-        let total_style = apply_highlight(normal_total, highlight_intensity);
-        cells.push(Cell::from(Span::styled(total_s, total_style)));
+        if self.show_total {
+            let total_s = format_tokens_short(total);
+            let normal_total = if use_color {
+                base_style.fg(theme::tokens_color(total))
+            } else {
+                base_style
+            };
+            let total_style = apply_highlight(normal_total, highlight_intensity);
+            cells.push(Cell::from(Span::styled(total_s, total_style)));
+        }
 
-        let cost_s = format_cost(cost);
-        let normal_cost = if use_color {
-            base_style.fg(theme::cost_color(cost))
-        } else {
-            base_style
-        };
-        let cost_style = apply_highlight(normal_cost, highlight_intensity);
-        cells.push(Cell::from(Span::styled(cost_s, cost_style)));
+        if self.show_cost {
+            let cost_s = format_cost(cost);
+            let normal_cost = if use_color {
+                base_style.fg(theme::cost_color(cost))
+            } else {
+                base_style
+            };
+            let cost_style = apply_highlight(normal_cost, highlight_intensity);
+            cells.push(Cell::from(Span::styled(cost_s, cost_style)));
+        }
 
         cells
     }
@@ -401,11 +417,15 @@ impl ColumnSet {
         if self.show_output {
             cells.push(Cell::from(Span::styled("", style)));
         }
-        cells.push(Cell::from(Span::styled(
-            format_tokens_short(total_tokens),
-            style,
-        )));
-        cells.push(Cell::from(Span::styled(format_cost(total_cost), style)));
+        if self.show_total {
+            cells.push(Cell::from(Span::styled(
+                format_tokens_short(total_tokens),
+                style,
+            )));
+        }
+        if self.show_cost {
+            cells.push(Cell::from(Span::styled(format_cost(total_cost), style)));
+        }
         cells
     }
 }
@@ -419,6 +439,8 @@ fn choose_columns(width: usize) -> ColumnSet {
             show_requests: true,
             show_input: true,
             show_output: true,
+            show_total: true,
+            show_cost: true,
         }
     } else if width >= 70 {
         ColumnSet {
@@ -427,6 +449,8 @@ fn choose_columns(width: usize) -> ColumnSet {
             show_requests: true,
             show_input: true,
             show_output: true,
+            show_total: true,
+            show_cost: true,
         }
     } else if width >= 56 {
         ColumnSet {
@@ -435,6 +459,8 @@ fn choose_columns(width: usize) -> ColumnSet {
             show_requests: true,
             show_input: true,
             show_output: true,
+            show_total: true,
+            show_cost: true,
         }
     } else if width >= 42 {
         ColumnSet {
@@ -443,6 +469,8 @@ fn choose_columns(width: usize) -> ColumnSet {
             show_requests: true,
             show_input: false,
             show_output: false,
+            show_total: true,
+            show_cost: true,
         }
     } else {
         ColumnSet {
@@ -451,6 +479,8 @@ fn choose_columns(width: usize) -> ColumnSet {
             show_requests: false,
             show_input: false,
             show_output: false,
+            show_total: true,
+            show_cost: true,
         }
     }
 }
@@ -464,4 +494,61 @@ fn apply_highlight(normal: Style, intensity: f64) -> Style {
     // Extract the foreground colour from the normal style, defaulting to FG
     let normal_fg = normal.fg.unwrap_or(theme::FG);
     theme::highlight_cell(intensity, normal_fg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masks_metric_columns_with_persisted_visibility() {
+        let mut config = ColumnConfig::default();
+        config.requests = false;
+        config.total_tokens = false;
+        config.cost = false;
+
+        let columns = choose_columns(100).mask(&config);
+
+        assert_eq!(
+            columns.headers(),
+            ["Model", "API", "Client", "Input", "Output"]
+        );
+        assert_eq!(columns.headers().len(), columns.widths().len());
+    }
+
+    #[test]
+    fn narrow_layout_still_applies_visibility_choices() {
+        let mut config = ColumnConfig::default();
+        config.cost = false;
+
+        let columns = choose_columns(30).mask(&config);
+
+        assert_eq!(columns.headers(), ["Model", "Total"]);
+        assert_eq!(columns.headers().len(), columns.widths().len());
+    }
+
+    #[test]
+    fn row_and_total_cells_match_visible_headers() {
+        let mut config = ColumnConfig::default();
+        config.total_tokens = false;
+        let columns = choose_columns(100).mask(&config);
+
+        let row = columns.build_row(
+            "model",
+            "api",
+            "client",
+            1,
+            2,
+            3,
+            5,
+            0.1,
+            Style::default(),
+            false,
+            0.0,
+        );
+        let total = columns.build_total_row(1, 5, 0.1);
+
+        assert_eq!(row.len(), columns.headers().len());
+        assert_eq!(total.len(), columns.headers().len());
+    }
 }


### PR DESCRIPTION
## Summary

- add persistent settings for Requests, Total Tokens, and Cost visibility
- apply the effective visibility mask consistently to headers, data rows, totals, and responsive layouts
- keep Cost visibility independent from disabling cost calculation
- preserve existing configuration files through defaulted fields

## Validation

- `cargo fmt -- --check`
- `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions`
- `cargo test`
- `cargo build --release`

Closes #28
