### PR TITLE
chore(release): prepare v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "tokemon"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokemon"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "Unified LLM token usage tracking across all providers"
 license = "MIT"


### PR DESCRIPTION
## Summary

- align the manifest and lockfile to version 0.2.6
- prepare the merged pricing routing fix and recent dashboard improvements for release

## Validation

- cargo fmt -- --check
- cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions
- cargo test
- cargo build --release
- cargo publish --dry-run --allow-dirty