### PR TITLE
feat(tui): add hover feedback

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -78,6 +78,13 @@ pub struct CardData {
     pub trend: i8,
 }
 
+/// Interactive region currently under the pointer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HoverTarget {
+    Card(Scope),
+    TableRow(RowKey),
+}
+
 impl CardData {
     #[must_use]
     pub fn cost_str(&self) -> String {
@@ -184,6 +191,8 @@ pub struct App {
     /// it was last updated. Used for the green fade animation on
     /// individual table cells.
     pub highlight_map: HashMap<RowKey, Instant>,
+    /// Interactive region currently under the pointer, if any.
+    pub(crate) hovered: Option<HoverTarget>,
     /// Last warning message from the background watcher or data loading,
     /// with the instant it was received. Displayed in the status bar
     /// for a few seconds then cleared.
@@ -278,6 +287,7 @@ impl App {
             applied_filter: String::new(),
             sort_order: SortOrder::CostDesc,
             highlight_map: HashMap::new(),
+            hovered: None,
             last_warning: None,
             show_settings: false,
             settings_state: SettingsState::new(config),
@@ -376,15 +386,25 @@ impl App {
 
     fn handle_mouse(&mut self, mouse: MouseEvent, terminal_area: Rect) -> bool {
         if self.show_settings || self.show_help || self.filter_active {
-            return false;
+            return self.set_hover(None);
         }
 
-        match dashboard::mouse_action(terminal_area, mouse) {
+        let hover_changed = self.set_hover(dashboard::hover_target(terminal_area, self, mouse));
+        let action_changed = match dashboard::mouse_action(terminal_area, mouse) {
             Some(MouseAction::SelectScope(scope)) => self.select_scope(scope),
             Some(MouseAction::ScrollUp) => self.scroll_up(MOUSE_SCROLL_ROWS),
             Some(MouseAction::ScrollDown) => self.scroll_down(MOUSE_SCROLL_ROWS),
             None => false,
+        };
+        hover_changed || action_changed
+    }
+
+    fn set_hover(&mut self, target: Option<HoverTarget>) -> bool {
+        if self.hovered == target {
+            return false;
         }
+        self.hovered = target;
+        true
     }
 
     /// Returns the current warning message if it's still fresh (< 5 seconds old).

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 pub enum Event {
     /// A key was pressed.
     Key(crossterm::event::KeyEvent),
-    /// A mouse button was pressed or the wheel was scrolled.
+    /// A mouse button was pressed, the wheel was scrolled, or the pointer moved.
     Mouse(crossterm::event::MouseEvent),
     /// Terminal was resized (values used by ratatui's `frame.area()` implicitly).
     #[allow(dead_code)]
@@ -124,6 +124,7 @@ fn map_crossterm_event(event: &CrosstermEvent) -> Option<Event> {
                 MouseEventKind::Down(MouseButton::Left)
                     | MouseEventKind::ScrollUp
                     | MouseEventKind::ScrollDown
+                    | MouseEventKind::Moved
             ) =>
         {
             Some(Event::Mouse(*mouse))
@@ -169,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_mouse_motion() {
+    fn routes_mouse_motion() {
         let mouse = MouseEvent {
             kind: MouseEventKind::Moved,
             column: 12,
@@ -177,6 +178,9 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
 
-        assert!(map_crossterm_event(&CrosstermEvent::Mouse(mouse)).is_none());
+        assert!(matches!(
+            map_crossterm_event(&CrosstermEvent::Mouse(mouse)),
+            Some(Event::Mouse(event)) if event == mouse
+        ));
     }
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -8,6 +8,9 @@ pub const BG: Color = Color::Rgb(15, 17, 22);
 /// Slightly lighter surface for panels / cards.
 pub const SURFACE: Color = Color::Rgb(22, 25, 33);
 
+/// Slightly lighter surface used for pointer hover feedback.
+pub const SURFACE_HOVER: Color = Color::Rgb(30, 34, 45);
+
 /// Borders, separators.
 pub const BORDER: Color = Color::Rgb(48, 54, 68);
 

--- a/src/tui/views/dashboard.rs
+++ b/src/tui/views/dashboard.rs
@@ -3,7 +3,7 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::widgets::Block;
 use ratatui::Frame;
 
-use crate::tui::app::App;
+use crate::tui::app::{App, HoverTarget};
 use crate::tui::theme;
 use crate::tui::views::{help, settings};
 use crate::tui::widgets::{header, status_bar, summary_cards, usage_table};
@@ -121,6 +121,21 @@ pub(crate) fn mouse_action(area: Rect, event: MouseEvent) -> Option<MouseAction>
         }
         _ => None,
     }
+}
+
+/// Resolve pointer movement to a rendered interactive region.
+#[must_use]
+pub(crate) fn hover_target(area: Rect, app: &App, event: MouseEvent) -> Option<HoverTarget> {
+    let layout = dashboard_layout(area);
+
+    layout
+        .summary_cards
+        .and_then(|cards| summary_cards::scope_at(cards, event.column, event.row))
+        .map(HoverTarget::Card)
+        .or_else(|| {
+            usage_table::row_at(layout.usage_table, app, event.column, event.row)
+                .map(HoverTarget::TableRow)
+        })
 }
 
 fn contains(area: Rect, column: u16, row: u16) -> bool {

--- a/src/tui/widgets/summary_cards.rs
+++ b/src/tui/widgets/summary_cards.rs
@@ -4,7 +4,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Sparkline};
 use ratatui::Frame;
 
-use crate::tui::app::{App, Scope};
+use crate::tui::app::{App, HoverTarget, Scope};
 use crate::tui::theme;
 
 /// Render the four summary cards: Today, This Week, This Month, All Time.
@@ -22,6 +22,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             card_area,
             &app.cards[i],
             scope == app.scope,
+            matches!(app.hovered.as_ref(), Some(HoverTarget::Card(hovered)) if *hovered == scope),
             show_sparklines,
         );
     }
@@ -66,11 +67,19 @@ fn render_card(
     area: Rect,
     card: &crate::tui::app::CardData,
     active: bool,
+    hovered: bool,
     show_sparklines: bool,
 ) {
+    let surface = if hovered {
+        theme::SURFACE_HOVER
+    } else {
+        theme::SURFACE
+    };
     // Card block with border
     let border_style = if active {
         theme::border().fg(theme::ACCENT)
+    } else if hovered {
+        theme::border().fg(theme::ACCENT_DIM)
     } else {
         theme::border()
     };
@@ -78,7 +87,7 @@ fn render_card(
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(border_style)
-        .style(theme::card());
+        .style(theme::card().bg(surface));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -112,9 +121,11 @@ fn render_card(
 
     // Label with trend indicator
     let label_style = if active {
-        theme::card_label().add_modifier(Modifier::UNDERLINED)
-    } else {
         theme::card_label()
+            .bg(surface)
+            .add_modifier(Modifier::UNDERLINED)
+    } else {
+        theme::card_label().bg(surface)
     };
     let trend_color = match card.trend.cmp(&0) {
         std::cmp::Ordering::Greater => theme::GREEN,
@@ -125,20 +136,24 @@ fn render_card(
         Span::styled(card.label, label_style),
         Span::styled(
             format!(" {}", card.trend_symbol()),
-            ratatui::style::Style::default()
-                .fg(trend_color)
-                .bg(theme::SURFACE),
+            ratatui::style::Style::default().fg(trend_color).bg(surface),
         ),
     ]);
     frame.render_widget(label, card_areas[0]);
 
     // Cost
-    let cost_line = Line::from(Span::styled(card.cost_str(), theme::card_value()));
+    let cost_line = Line::from(Span::styled(
+        card.cost_str(),
+        theme::card_value().bg(surface),
+    ));
     frame.render_widget(cost_line, card_areas[1]);
 
     // Tokens (if space)
     if card_areas.len() >= 3 {
-        let tokens_line = Line::from(Span::styled(card.tokens_str(), theme::card_secondary()));
+        let tokens_line = Line::from(Span::styled(
+            card.tokens_str(),
+            theme::card_secondary().bg(surface),
+        ));
         frame.render_widget(tokens_line, card_areas[2]);
     }
 
@@ -160,7 +175,7 @@ fn render_card(
                 } else {
                     theme::ACCENT_DIM
                 })
-                .bg(theme::SURFACE),
+                .bg(surface),
         );
         frame.render_widget(sparkline, card_areas[3]);
     }

--- a/src/tui/widgets/usage_table.rs
+++ b/src/tui/widgets/usage_table.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 use crate::config::ColumnConfig;
 use crate::display;
 use crate::render::{format_cost, format_tokens_short};
-use crate::tui::app::App;
+use crate::tui::app::{App, HoverTarget};
 use crate::tui::diff::RowKey;
 use crate::tui::theme;
 
@@ -131,6 +131,15 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                         ),
                     };
 
+                    let hovered = matches!(
+                        app.hovered.as_ref(),
+                        Some(HoverTarget::TableRow(hovered_key)) if hovered_key == &RowKey::from(mu)
+                    );
+                    let sub_style = if hovered {
+                        sub_style.bg(theme::SURFACE_HOVER)
+                    } else {
+                        sub_style
+                    };
                     let sub_cells = cols.build_row(
                         &name_col,
                         &api_col,
@@ -178,6 +187,15 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
             let row_key = RowKey::from(mu);
             let intensity = app.highlight_intensity(&row_key);
 
+            let hovered = matches!(
+                app.hovered.as_ref(),
+                Some(HoverTarget::TableRow(hovered_key)) if hovered_key == &row_key
+            );
+            let row_style = if hovered {
+                theme::text().bg(theme::SURFACE_HOVER)
+            } else {
+                theme::text()
+            };
             let cells = cols.build_row(
                 &name_col,
                 &api_col,
@@ -187,7 +205,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 mu.output_tokens,
                 total,
                 mu.cost_usd,
-                theme::text(),
+                row_style,
                 true,
                 intensity,
             );
@@ -216,6 +234,51 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     // Clamp scroll_offset if it exceeds available rows (borrow after rendering)
     // This is a visual-only clamp; actual state clamping happens in app.rs
+}
+
+/// Return the model row under a terminal coordinate, accounting for the
+/// table header and current scroll offset. Non-model rows are not interactive.
+#[must_use]
+pub(crate) fn row_at(area: Rect, app: &App, column: u16, row: u16) -> Option<RowKey> {
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    if inner.height < 3
+        || inner.width < 20
+        || (app.detail_models.is_empty() && app.history_summaries.is_empty())
+        || column < inner.x
+        || column >= inner.x.saturating_add(inner.width)
+        || row < inner.y.saturating_add(1)
+        || row >= inner.y.saturating_add(inner.height)
+    {
+        return None;
+    }
+
+    let body_index = body_row_index(inner, app.scroll_offset, row)?;
+    row_keys(app).get(body_index).and_then(Clone::clone)
+}
+
+fn body_row_index(inner: Rect, scroll_offset: u16, row: u16) -> Option<usize> {
+    (row >= inner.y.saturating_add(1) && row < inner.y.saturating_add(inner.height)).then(|| {
+        scroll_offset.saturating_add(row.saturating_sub(inner.y).saturating_sub(1)) as usize
+    })
+}
+
+fn row_keys(app: &App) -> Vec<Option<RowKey>> {
+    let mut rows: Vec<Option<RowKey>> = if app.show_history && !app.history_summaries.is_empty() {
+        app.history_summaries
+            .iter()
+            .flat_map(|summary| {
+                std::iter::once(None)
+                    .chain(summary.models.iter().map(|model| Some(RowKey::from(model))))
+            })
+            .collect()
+    } else {
+        app.detail_models
+            .iter()
+            .map(|model| Some(RowKey::from(model)))
+            .collect()
+    };
+    rows.push(None); // TOTAL row
+    rows
 }
 
 // ── Column management ─────────────────────────────────────────────────────
@@ -499,6 +562,16 @@ fn apply_highlight(normal: Style, intensity: f64) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn body_row_index_skips_header_and_applies_scroll() {
+        let inner = Rect::new(2, 4, 40, 8);
+
+        assert_eq!(body_row_index(inner, 3, 4), None);
+        assert_eq!(body_row_index(inner, 3, 5), Some(3));
+        assert_eq!(body_row_index(inner, 3, 11), Some(9));
+        assert_eq!(body_row_index(inner, 3, 12), None);
+    }
 
     #[test]
     fn masks_metric_columns_with_persisted_visibility() {


### PR DESCRIPTION
Fixes #27.

## What changed

- route pointer movement events into the TUI without changing keyboard behavior
- track hovered summary cards and visible usage rows with responsive hit-testing
- apply a subtle surface and border change to hovered cards and rows
- clear hover state outside interactive regions and avoid redraws for unchanged targets

## Validation

- `cargo fmt -- --check`
- `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions`
- `cargo test`
- `cargo build --release`
- `git diff --check`
