### PR TITLE
feat: add interactive configuration editor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,8 @@ pub enum Commands {
     Discover,
     /// Generate default config file at ~/.config/tokemon/config.toml
     Init,
+    /// Open the interactive configuration editor
+    Config,
     /// Show per-session cost breakdown
     Sessions {
         /// Show top N sessions by cost

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -303,18 +304,59 @@ impl Config {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let content = toml::to_string_pretty(self)?;
+        let mut document = match fs::read_to_string(&path) {
+            Ok(existing) => toml::from_str::<toml::Value>(&existing)
+                .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new())),
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                toml::Value::Table(toml::map::Map::new())
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let updated = toml::Value::try_from(self)?;
+        merge_toml_tables(&mut document, updated);
+        let content = toml::to_string_pretty(&document)?;
         let header = "# Tokemon configuration\n\
                       # Location: ~/.config/tokemon/config.toml\n\
                       #\n\
                       # Changes here affect default behavior.\n\
                       # CLI flags always override config values.\n\n";
-        fs::write(&path, format!("{header}{content}"))?;
+        let temporary_path = path.with_extension(format!("toml.{}.tmp", std::process::id()));
+        fs::write(&temporary_path, format!("{header}{content}"))?;
+        match fs::rename(&temporary_path, &path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                fs::remove_file(&path)?;
+                fs::rename(&temporary_path, &path)?;
+            }
+            Err(error) => {
+                let _ = fs::remove_file(&temporary_path);
+                return Err(error.into());
+            }
+        }
         Ok(())
     }
 
     pub fn config_path() -> PathBuf {
         paths::config_dir().join(CONFIG_FILENAME)
+    }
+}
+
+fn merge_toml_tables(existing: &mut toml::Value, updated: toml::Value) {
+    match updated {
+        toml::Value::Table(updated_table) => {
+            if let toml::Value::Table(existing_table) = existing {
+                for (key, value) in updated_table {
+                    if let Some(existing_value) = existing_table.get_mut(&key) {
+                        merge_toml_tables(existing_value, value);
+                    } else {
+                        existing_table.insert(key, value);
+                    }
+                }
+            } else {
+                *existing = toml::Value::Table(updated_table);
+            }
+        }
+        updated => *existing = updated,
     }
 }
 
@@ -417,5 +459,32 @@ mod tests {
         assert_eq!(validated.week_bucket_hours, 4);
         assert_eq!(validated.month_bucket_days, 1);
         assert_eq!(validated.tick_interval, 300); // Clamped to 300
+    }
+
+    #[test]
+    fn merging_saved_values_preserves_unknown_keys() {
+        let mut existing: toml::Value = toml::from_str(
+            r#"
+            custom_option = "keep"
+            [columns]
+            custom_column = true
+            cost = false
+            "#,
+        )
+        .expect("valid TOML");
+        let updated: toml::Value = toml::from_str(
+            r#"
+            [columns]
+            cost = true
+            "#,
+        )
+        .expect("valid TOML");
+
+        merge_toml_tables(&mut existing, updated);
+
+        let table = existing.as_table().expect("root table");
+        assert_eq!(table["custom_option"].as_str(), Some("keep"));
+        assert_eq!(table["columns"]["custom_column"].as_bool(), Some(true));
+        assert_eq!(table["columns"]["cost"].as_bool(), Some(true));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ fn main() -> anyhow::Result<()> {
             Ok(())
         }
         Commands::Init => cmd_init(),
+        Commands::Config => tui::run_config(&config, cli.offline || config.offline),
         Commands::Statusline => cmd_statusline(&cli, &config),
         Commands::Budget => cmd_budget(&cli, &config),
         Commands::Sessions { top } => cmd_sessions(&cli, &config, *top),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -274,6 +274,8 @@ pub struct App {
     pub spike_data: Option<SpikeSeries>,
     /// Whether the settings overlay is shown.
     pub show_settings: bool,
+    /// Whether this session should exit when the settings overlay closes.
+    pub(crate) config_only: bool,
     /// Settings editor state.
     pub settings_state: SettingsState,
     /// Whether the UI state has changed and needs a redraw.
@@ -369,6 +371,7 @@ impl App {
             heatmap_data: Vec::new(),
             spike_data: None,
             show_settings: false,
+            config_only: false,
             settings_state: SettingsState::new(config),
             dirty: true,
             config: config.clone(),
@@ -718,6 +721,17 @@ impl App {
 
     #[allow(clippy::too_many_lines)]
     fn handle_settings_key(&mut self, key: KeyEvent) -> bool {
+        if self.settings_state.confirming_save {
+            return match key.code {
+                KeyCode::Char('y' | 'Y') | KeyCode::Enter => self.save_settings(),
+                KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+                    self.settings_state.confirming_save = false;
+                    true
+                }
+                _ => false,
+            };
+        }
+
         let state = &mut self.settings_state;
 
         // If editing a text/numeric field
@@ -725,8 +739,11 @@ impl App {
             match key.code {
                 KeyCode::Enter => {
                     let field = state.current_field();
-                    if field.apply_value(&mut state.draft, &state.edit_buffer) {
-                        state.unsaved = true;
+                    match field.apply_value(&mut state.draft, &state.edit_buffer) {
+                        Ok(()) => state.unsaved = true,
+                        Err(message) => {
+                            state.flash_message = Some((message.to_string(), Instant::now()));
+                        }
                     }
                     state.editing = false;
                     state.edit_buffer.clear();
@@ -737,7 +754,9 @@ impl App {
                     state.edit_buffer.clear();
                     return true;
                 }
-                KeyCode::Char(c) if c.is_ascii_digit() || c == '.' => {
+                KeyCode::Char(c)
+                    if state.current_field().is_text() || c.is_ascii_digit() || c == '.' =>
+                {
                     state.edit_buffer.push(c);
                     return true;
                 }
@@ -754,6 +773,9 @@ impl App {
             KeyCode::Esc | KeyCode::Char('S') => {
                 // Close settings, discard unsaved changes
                 self.show_settings = false;
+                if self.config_only {
+                    self.should_quit = true;
+                }
                 true
             }
             KeyCode::Char('j') | KeyCode::Down => {
@@ -803,31 +825,35 @@ impl App {
                 }
             }
             KeyCode::Char('W') => {
-                // Save to disk
-                let old_metric = self.config.sparkline_metric;
-                match self.settings_state.draft.save() {
-                    Ok(()) => {
-                        self.config = self.settings_state.draft.clone();
-                        self.no_cost = self.settings_state.draft.no_cost;
-                        self.settings_state.unsaved = false;
-                        self.settings_state.flash_message =
-                            Some(("Saved!".to_string(), Instant::now()));
-                        // Recompute all-time base if sparkline metric changed
-                        if self.config.sparkline_metric != old_metric {
-                            if let Err(e) = self.compute_all_time_base() {
-                                self.set_warning(format!("History refresh failed: {e}"));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        self.last_warning =
-                            Some((format!("Failed to save config: {e}"), Instant::now()));
-                    }
-                }
+                self.settings_state.confirming_save = self.settings_state.unsaved;
                 true
             }
             _ => false,
         }
+    }
+
+    fn save_settings(&mut self) -> bool {
+        let old_metric = self.config.sparkline_metric;
+        match self.settings_state.draft.save() {
+            Ok(()) => {
+                self.config = self.settings_state.draft.clone();
+                self.no_cost = self.settings_state.draft.no_cost;
+                self.settings_state.unsaved = false;
+                self.settings_state.confirming_save = false;
+                self.settings_state.flash_message = Some(("Saved!".to_string(), Instant::now()));
+                if self.config.sparkline_metric != old_metric {
+                    if let Err(e) = self.compute_all_time_base() {
+                        self.set_warning(format!("History refresh failed: {e}"));
+                    }
+                }
+            }
+            Err(error) => {
+                self.settings_state.confirming_save = false;
+                self.settings_state.flash_message =
+                    Some((format!("Failed to save config: {error}"), Instant::now()));
+            }
+        }
+        true
     }
 
     /// Load all records older than the in-memory window, apply pricing,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,7 +55,17 @@ pub fn run(
         .enable_all()
         .build()?;
 
-    runtime.block_on(async { run_async(config, scope, tick_secs, offline).await })
+    runtime.block_on(async { run_async(config, scope, tick_secs, offline, false).await })
+}
+
+/// Run the keyboard-driven configuration editor without requiring a dashboard session.
+pub fn run_config(config: &Config, offline: bool) -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    runtime
+        .block_on(async { run_async(config, Scope::Today, DEFAULT_TICK_SECS, offline, true).await })
 }
 
 async fn run_async(
@@ -63,10 +73,13 @@ async fn run_async(
     scope: Scope,
     tick_secs: u64,
     offline: bool,
+    config_only: bool,
 ) -> anyhow::Result<()> {
     let mut terminal = terminal::init()?;
     let mut terminal_area = Rect::from(terminal.size()?);
     let mut app = App::new(config, scope, offline);
+    app.config_only = config_only;
+    app.show_settings = config_only;
 
     let mut events = EventHandler::new(
         Duration::from_secs(tick_secs),

--- a/src/tui/settings_state.rs
+++ b/src/tui/settings_state.rs
@@ -8,8 +8,13 @@ use crate::config::Config;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SettingField {
     TickInterval,
-    NoCost,
     DefaultCommand,
+    DefaultFormat,
+    Breakdown,
+    NoCost,
+    Offline,
+    Refresh,
+    Reparse,
     SortOrder,
     ShowSparklines,
     SparklineMetric,
@@ -19,10 +24,15 @@ pub(crate) enum SettingField {
     BudgetDaily,
     BudgetWeekly,
     BudgetMonthly,
+    Providers,
+    ColDate,
+    ColModel,
     ColApiProvider,
     ColClient,
     ColInput,
     ColOutput,
+    ColCacheWrite,
+    ColCacheRead,
     ColRequests,
     ColTotalTokens,
     ColCost,
@@ -30,13 +40,18 @@ pub(crate) enum SettingField {
 
 impl SettingField {
     /// Total number of settings fields.
-    pub const COUNT: usize = 19;
+    pub const COUNT: usize = 29;
 
     /// All fields in display order.
     pub const ALL: [Self; Self::COUNT] = [
         Self::TickInterval,
-        Self::NoCost,
         Self::DefaultCommand,
+        Self::DefaultFormat,
+        Self::Breakdown,
+        Self::NoCost,
+        Self::Offline,
+        Self::Refresh,
+        Self::Reparse,
         Self::SortOrder,
         Self::ShowSparklines,
         Self::SparklineMetric,
@@ -46,10 +61,15 @@ impl SettingField {
         Self::BudgetDaily,
         Self::BudgetWeekly,
         Self::BudgetMonthly,
+        Self::Providers,
+        Self::ColDate,
+        Self::ColModel,
         Self::ColApiProvider,
         Self::ColClient,
         Self::ColInput,
         Self::ColOutput,
+        Self::ColCacheWrite,
+        Self::ColCacheRead,
         Self::ColRequests,
         Self::ColTotalTokens,
         Self::ColCost,
@@ -60,8 +80,13 @@ impl SettingField {
     pub fn label(self) -> &'static str {
         match self {
             Self::TickInterval => "Tick Interval (s) *",
-            Self::NoCost => "Disable Costs",
             Self::DefaultCommand => "Default Command",
+            Self::DefaultFormat => "Default Format",
+            Self::Breakdown => "Model Breakdown",
+            Self::NoCost => "Disable Costs",
+            Self::Offline => "Offline Pricing",
+            Self::Refresh => "Always Refresh",
+            Self::Reparse => "Always Reparse",
             Self::SortOrder => "Sort Order",
             Self::ShowSparklines => "Show Sparklines",
             Self::SparklineMetric => "Sparkline Metric",
@@ -71,10 +96,15 @@ impl SettingField {
             Self::BudgetDaily => "Daily Budget ($)",
             Self::BudgetWeekly => "Weekly Budget ($)",
             Self::BudgetMonthly => "Monthly Budget ($)",
+            Self::Providers => "Providers (comma-separated)",
+            Self::ColDate => "Date",
+            Self::ColModel => "Model",
             Self::ColApiProvider => "API Provider",
             Self::ColClient => "Client",
             Self::ColInput => "Input Tokens",
             Self::ColOutput => "Output Tokens",
+            Self::ColCacheWrite => "Cache Write",
+            Self::ColCacheRead => "Cache Read",
             Self::ColRequests => "Requests",
             Self::ColTotalTokens => "Total Tokens",
             Self::ColCost => "Cost",
@@ -86,9 +116,11 @@ impl SettingField {
     pub fn section_header(self) -> Option<&'static str> {
         match self {
             Self::TickInterval => Some("General"),
+            Self::DefaultCommand => Some("Defaults"),
             Self::ShowSparklines => Some("Sparklines"),
             Self::BudgetDaily => Some("Budget Limits"),
-            Self::ColApiProvider => Some("Columns"),
+            Self::Providers => Some("Sources"),
+            Self::ColDate => Some("Columns"),
             _ => None,
         }
     }
@@ -98,12 +130,20 @@ impl SettingField {
     pub fn is_bool(self) -> bool {
         matches!(
             self,
-            Self::NoCost
+            Self::Breakdown
+                | Self::NoCost
+                | Self::Offline
+                | Self::Refresh
+                | Self::Reparse
                 | Self::ShowSparklines
+                | Self::ColDate
+                | Self::ColModel
                 | Self::ColApiProvider
                 | Self::ColClient
                 | Self::ColInput
                 | Self::ColOutput
+                | Self::ColCacheWrite
+                | Self::ColCacheRead
                 | Self::ColRequests
                 | Self::ColTotalTokens
                 | Self::ColCost
@@ -115,8 +155,14 @@ impl SettingField {
     pub fn is_enum(self) -> bool {
         matches!(
             self,
-            Self::DefaultCommand | Self::SortOrder | Self::SparklineMetric
+            Self::DefaultCommand | Self::DefaultFormat | Self::SortOrder | Self::SparklineMetric
         )
+    }
+
+    /// Whether this field accepts free-form text input.
+    #[must_use]
+    pub fn is_text(self) -> bool {
+        matches!(self, Self::Providers)
     }
 
     /// Get the current value as a display string from a config.
@@ -131,8 +177,13 @@ impl SettingField {
                     v.to_string()
                 }
             }
-            Self::NoCost => if config.no_cost { "Yes" } else { "No" }.to_string(),
             Self::DefaultCommand => config.default_command.to_string(),
+            Self::DefaultFormat => config.default_format.clone(),
+            Self::Breakdown => bool_display(config.breakdown),
+            Self::NoCost => bool_display(config.no_cost),
+            Self::Offline => bool_display(config.offline),
+            Self::Refresh => bool_display(config.refresh),
+            Self::Reparse => bool_display(config.reparse),
             Self::SortOrder => config.sort_order.to_string(),
             Self::ShowSparklines => if config.show_sparklines { "Yes" } else { "No" }.to_string(),
             Self::SparklineMetric => config.sparkline_metric.to_string(),
@@ -151,10 +202,21 @@ impl SettingField {
                 .budget
                 .monthly
                 .map_or("--".to_string(), |v| format!("{v:.2}")),
+            Self::Providers => {
+                if config.providers.is_empty() {
+                    "(all)".to_string()
+                } else {
+                    config.providers.join(", ")
+                }
+            }
+            Self::ColDate => bool_display(config.columns.date),
+            Self::ColModel => bool_display(config.columns.model),
             Self::ColApiProvider => bool_display(config.columns.api_provider),
             Self::ColClient => bool_display(config.columns.client),
             Self::ColInput => bool_display(config.columns.input),
             Self::ColOutput => bool_display(config.columns.output),
+            Self::ColCacheWrite => bool_display(config.columns.cache_write),
+            Self::ColCacheRead => bool_display(config.columns.cache_read),
             Self::ColRequests => bool_display(config.columns.requests),
             Self::ColTotalTokens => bool_display(config.columns.total_tokens),
             Self::ColCost => bool_display(config.columns.cost),
@@ -164,12 +226,20 @@ impl SettingField {
     /// Toggle a boolean field on the given config. No-op for non-bool fields.
     pub fn toggle_bool(self, config: &mut Config) {
         match self {
+            Self::Breakdown => config.breakdown = !config.breakdown,
             Self::NoCost => config.no_cost = !config.no_cost,
+            Self::Offline => config.offline = !config.offline,
+            Self::Refresh => config.refresh = !config.refresh,
+            Self::Reparse => config.reparse = !config.reparse,
             Self::ShowSparklines => config.show_sparklines = !config.show_sparklines,
+            Self::ColDate => config.columns.date = !config.columns.date,
+            Self::ColModel => config.columns.model = !config.columns.model,
             Self::ColApiProvider => config.columns.api_provider = !config.columns.api_provider,
             Self::ColClient => config.columns.client = !config.columns.client,
             Self::ColInput => config.columns.input = !config.columns.input,
             Self::ColOutput => config.columns.output = !config.columns.output,
+            Self::ColCacheWrite => config.columns.cache_write = !config.columns.cache_write,
+            Self::ColCacheRead => config.columns.cache_read = !config.columns.cache_read,
             Self::ColRequests => config.columns.requests = !config.columns.requests,
             Self::ColTotalTokens => config.columns.total_tokens = !config.columns.total_tokens,
             Self::ColCost => config.columns.cost = !config.columns.cost,
@@ -183,6 +253,13 @@ impl SettingField {
             Self::DefaultCommand => {
                 config.default_command = config.default_command.next();
             }
+            Self::DefaultFormat => {
+                config.default_format = if config.default_format == "json" {
+                    "table".to_string()
+                } else {
+                    "json".to_string()
+                };
+            }
             Self::SortOrder => {
                 config.sort_order = config.sort_order.next();
             }
@@ -194,45 +271,62 @@ impl SettingField {
     }
 
     /// Apply a string value from the edit buffer to the config.
-    /// Returns `true` if the value was valid and applied.
-    pub fn apply_value(self, config: &mut Config, value: &str) -> bool {
+    /// Returns an error when the value is outside the accepted range.
+    pub fn apply_value(self, config: &mut Config, value: &str) -> Result<(), &'static str> {
         match self {
             Self::TickInterval => {
-                if let Ok(v) = value.parse::<u64>() {
-                    config.tick_interval = v.min(300);
-                    true
-                } else {
-                    false
+                let v = value
+                    .parse::<u64>()
+                    .map_err(|_| "Enter a whole number from 0 to 300")?;
+                if v > 300 {
+                    return Err("Tick interval must be between 0 and 300 seconds");
                 }
+                config.tick_interval = v;
+                Ok(())
             }
             Self::TodayBucketMins => {
-                if let Ok(v) = value.parse::<u64>() {
-                    config.today_bucket_mins = v.clamp(1, 60);
-                    true
-                } else {
-                    false
+                let v = value
+                    .parse::<u64>()
+                    .map_err(|_| "Enter a whole number from 1 to 60")?;
+                if !(1..=60).contains(&v) {
+                    return Err("Today bucket must be between 1 and 60 minutes");
                 }
+                config.today_bucket_mins = v;
+                Ok(())
             }
             Self::WeekBucketHours => {
-                if let Ok(v) = value.parse::<u64>() {
-                    config.week_bucket_hours = v.clamp(1, 24);
-                    true
-                } else {
-                    false
+                let v = value
+                    .parse::<u64>()
+                    .map_err(|_| "Enter a whole number from 1 to 24")?;
+                if !(1..=24).contains(&v) {
+                    return Err("Week bucket must be between 1 and 24 hours");
                 }
+                config.week_bucket_hours = v;
+                Ok(())
             }
             Self::MonthBucketDays => {
-                if let Ok(v) = value.parse::<u64>() {
-                    config.month_bucket_days = v.clamp(1, 7);
-                    true
-                } else {
-                    false
+                let v = value
+                    .parse::<u64>()
+                    .map_err(|_| "Enter a whole number from 1 to 7")?;
+                if !(1..=7).contains(&v) {
+                    return Err("Month bucket must be between 1 and 7 days");
                 }
+                config.month_bucket_days = v;
+                Ok(())
             }
             Self::BudgetDaily => apply_budget_value(&mut config.budget.daily, value),
             Self::BudgetWeekly => apply_budget_value(&mut config.budget.weekly, value),
             Self::BudgetMonthly => apply_budget_value(&mut config.budget.monthly, value),
-            _ => false,
+            Self::Providers => {
+                config.providers = value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|provider| !provider.is_empty())
+                    .map(str::to_string)
+                    .collect();
+                Ok(())
+            }
+            _ => Err("This setting is not text-editable"),
         }
     }
 
@@ -256,6 +350,7 @@ impl SettingField {
                 .budget
                 .monthly
                 .map_or(String::new(), |v| format!("{v:.2}")),
+            Self::Providers => config.providers.join(", "),
             _ => String::new(),
         }
     }
@@ -265,20 +360,19 @@ pub(crate) fn bool_display(v: bool) -> String {
     if v { "Yes" } else { "No" }.to_string()
 }
 
-fn apply_budget_value(target: &mut Option<f64>, value: &str) -> bool {
+fn apply_budget_value(target: &mut Option<f64>, value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
         *target = None;
-        return true;
+        return Ok(());
     }
-    if let Ok(v) = value.parse::<f64>() {
-        if v > 0.0 && v.is_finite() {
-            *target = Some(v);
-        } else {
-            *target = None;
-        }
-        true
+    let v = value
+        .parse::<f64>()
+        .map_err(|_| "Enter a positive number or leave blank")?;
+    if v > 0.0 && v.is_finite() {
+        *target = Some(v);
+        Ok(())
     } else {
-        false
+        Err("Budget must be a positive finite number")
     }
 }
 
@@ -292,6 +386,8 @@ pub(crate) struct SettingsState {
     pub selected: usize,
     /// Whether we're currently editing a text/numeric field.
     pub editing: bool,
+    /// Whether the user is reviewing a save before it is written.
+    pub confirming_save: bool,
     /// Text buffer for the field being edited.
     pub edit_buffer: String,
     /// Brief confirmation message (e.g. "Saved!"), with the instant it was set.
@@ -305,6 +401,7 @@ impl SettingsState {
             unsaved: false,
             selected: 0,
             editing: false,
+            confirming_save: false,
             edit_buffer: String::new(),
             flash_message: None,
         }
@@ -354,5 +451,31 @@ mod tests {
         assert!(!config.columns.requests);
         assert!(!config.columns.total_tokens);
         assert!(!config.columns.cost);
+    }
+
+    #[test]
+    fn invalid_numeric_values_are_rejected_without_clamping() {
+        let mut config = Config::default();
+        assert!(SettingField::TickInterval
+            .apply_value(&mut config, "301")
+            .is_err());
+        assert_eq!(config.tick_interval, 0);
+        assert!(SettingField::TodayBucketMins
+            .apply_value(&mut config, "0")
+            .is_err());
+        assert_eq!(config.today_bucket_mins, 10);
+        assert!(SettingField::BudgetDaily
+            .apply_value(&mut config, "-1")
+            .is_err());
+        assert!(config.budget.daily.is_none());
+    }
+
+    #[test]
+    fn providers_are_editable_as_a_comma_separated_list() {
+        let mut config = Config::default();
+        SettingField::Providers
+            .apply_value(&mut config, "alpha, beta")
+            .expect("provider list should apply");
+        assert_eq!(config.providers, ["alpha", "beta"]);
     }
 }

--- a/src/tui/views/settings.rs
+++ b/src/tui/views/settings.rs
@@ -3,6 +3,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
+use crate::config::Config;
 use crate::tui::app::App;
 use crate::tui::settings_state::SettingField;
 use crate::tui::theme;
@@ -14,7 +15,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     let state = &app.settings_state;
 
     // Size: wide enough for labels + values, tall enough for all fields + sections + footer
-    let popup_width = area.width.min(60);
+    let popup_width = area.width.min(80);
     let popup_height = area.height.min(32);
 
     let popup_area = centered_rect(popup_width, popup_height, area);
@@ -23,10 +24,12 @@ pub fn render(frame: &mut Frame, app: &App) {
     frame.render_widget(Clear, popup_area);
 
     // Title with unsaved indicator
-    let title = if state.unsaved {
-        " Settings [modified] "
+    let title = if state.confirming_save {
+        " Save changes? ".to_string()
+    } else if state.unsaved {
+        " Settings [modified] ".to_string()
     } else {
-        " Settings "
+        " Settings ".to_string()
     };
 
     let block = Block::default()
@@ -45,6 +48,22 @@ pub fn render(frame: &mut Frame, app: &App) {
     // Build the content lines, tracking which line index each field maps to.
     let mut lines: Vec<Line> = Vec::with_capacity(SettingField::COUNT + 10);
     let mut field_line_indices: Vec<usize> = Vec::with_capacity(SettingField::COUNT);
+
+    let config_path = Config::config_path();
+    let source_label = if config_path.exists() {
+        "saved configuration"
+    } else {
+        "built-in defaults (file will be created on save)"
+    };
+    lines.push(Line::from(Span::styled(
+        format!("  Source: {source_label}"),
+        theme::text_dim(),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("  Path: {}", config_path.display()),
+        theme::text_dim(),
+    )));
+    lines.push(Line::from(""));
 
     for (idx, field) in SettingField::ALL.iter().enumerate() {
         // Section header
@@ -165,11 +184,18 @@ pub fn render(frame: &mut Frame, app: &App) {
     let mut footer_lines: Vec<Line> = Vec::new();
 
     // Unsaved changes prompt
-    if state.unsaved {
+    if state.confirming_save {
+        footer_lines.push(Line::from(vec![
+            Span::styled("  Y/Enter", theme::status_key()),
+            Span::styled(": Confirm save  ", theme::card_secondary()),
+            Span::styled("N/Esc", theme::status_key()),
+            Span::styled(": Cancel", theme::card_secondary()),
+        ]));
+    } else if state.unsaved {
         footer_lines.push(Line::from(vec![
             Span::styled("  W", theme::status_key()),
             Span::styled(
-                ": Save changes  ",
+                ": Review save  ",
                 ratatui::style::Style::default()
                     .fg(theme::YELLOW)
                     .bg(theme::SURFACE),


### PR DESCRIPTION
## Summary

- add a `config` command that opens the keyboard-driven configuration editor
- expose existing defaults, pricing, budget, refresh, source-filter, sparkline, and column settings
- show the configuration source and destination path before saving
- validate edited values, require explicit save confirmation, and report errors in the editor
- preserve unknown TOML keys and write configuration updates through a temporary file rename

## Scope

This implements the first, existing-settings slice of #24. Declarative custom-source authoring and a machine-readable client status contract remain separate work.

## Validation

- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions`
- `cargo build --release`
- `cargo run --quiet -- config --help`

Fixes #24
