### PR TITLE
feat: add versioned JSON status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Unified token usage tracking across all your AI coding tools. `tokemon top` prov
 - **SQLite cache** — parsed data is cached for instant repeated runs and survives log rotation
 - **Budget pacemaker** — set daily/weekly/monthly spending limits with progress tracking
 - **Statusline mode** — compact one-line output for shell prompts and status bars (`tokemon statusline`)
+- **Versioned status JSON** — stable machine-readable summaries for lightweight clients (`tokemon status --json`)
 - **Session breakdown** — per-session cost analysis across all providers (`tokemon sessions`)
 - **MCP server** — expose usage data to AI tools via Model Context Protocol (`tokemon mcp`)
 - **Two display modes** — compact one-row-per-day (default) or detailed per-model breakdown with responsive API Provider and Client columns
@@ -111,6 +112,7 @@ tokemon [OPTIONS] <COMMAND>
 Commands:
   top          Live monitoring dashboard
   report       Generate a static usage report (table, json, or csv)
+  status       Emit a versioned machine-readable status document
   statusline   Compact one-line output for shell prompts and status bars
   budget       Show spending vs configured limits
   sessions     Show per-session cost breakdown

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,8 @@ pub enum Frequency {
 pub enum Commands {
     /// Generate a static usage report (table, json, or csv)
     Report,
+    /// Emit a versioned machine-readable status document
+    Status,
     /// Compact one-line output for shell prompts and status bars
     Statusline,
     /// Show budget progress against configured limits

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use cli::{Cli, Commands, Frequency, SourceCommands};
 use config::Config;
 use pipeline::load_and_price;
 use source::{Source, SourceSet};
-use types::{Report, SessionReport};
+use types::{Report, SessionReport, StatusCapabilities, StatusReport, StatusScope};
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -45,6 +45,7 @@ fn main() -> anyhow::Result<()> {
 
     match &cli.command {
         Commands::Report => cmd_report(&cli, &config),
+        Commands::Status => cmd_status(&cli, &config),
         Commands::Discover => {
             cmd_discover();
             Ok(())
@@ -245,6 +246,61 @@ fn cmd_report(cli: &Cli, config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn cmd_status(cli: &Cli, config: &Config) -> anyhow::Result<()> {
+    let freq = cli.frequency;
+    let entries = load_and_price(
+        &pipeline::PipelineOptions::from_cli_config(cli, config),
+        false,
+    )?;
+
+    let mut summaries = match freq {
+        Frequency::Weekly => rollup::aggregate_weekly(&entries),
+        Frequency::Monthly => rollup::aggregate_monthly(&entries),
+        Frequency::Daily => rollup::aggregate_daily(&entries),
+    };
+    summaries.sort_unstable_by_key(|summary| summary.date);
+
+    let providers: Vec<String> = entries
+        .iter()
+        .map(|entry| entry.provider.to_string())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let total_cost = summaries.iter().map(|summary| summary.total_cost).sum();
+    let total_tokens = entries.iter().map(types::Record::total_tokens).sum();
+    let total_requests = summaries.iter().map(|summary| summary.total_requests).sum();
+
+    let status = StatusReport {
+        schema_version: 1,
+        generated_at: Utc::now(),
+        state: if entries.is_empty() {
+            "empty".to_string()
+        } else {
+            "populated".to_string()
+        },
+        scope: StatusScope {
+            frequency: frequency_label(freq).to_string(),
+            since: cli.since,
+            until: cli.until,
+        },
+        providers,
+        summaries,
+        total_cost,
+        total_tokens,
+        total_requests,
+        capabilities: StatusCapabilities {
+            cost: !cli.no_cost && !config.no_cost,
+            date_filters: true,
+            provider_filters: true,
+            periodic_summaries: true,
+            session_view: true,
+        },
+    };
+
+    render::print_status_json(&status);
+    Ok(())
+}
+
 fn cmd_statusline(cli: &Cli, config: &Config) -> anyhow::Result<()> {
     let freq = cli.frequency;
     let since = frequency_since(freq);
@@ -388,5 +444,13 @@ fn format_provider_count(count: usize) -> String {
         "1 provider".to_string()
     } else {
         format!("{count} providers")
+    }
+}
+
+fn frequency_label(freq: Frequency) -> &'static str {
+    match freq {
+        Frequency::Daily => "daily",
+        Frequency::Weekly => "weekly",
+        Frequency::Monthly => "monthly",
     }
 }

--- a/src/render/json.rs
+++ b/src/render/json.rs
@@ -1,4 +1,4 @@
-use crate::types::{Report, SessionReport};
+use crate::types::{Report, SessionReport, StatusReport};
 
 pub fn print_json(report: &Report) {
     match serde_json::to_string_pretty(report) {
@@ -11,5 +11,12 @@ pub fn print_sessions_json(report: &SessionReport) {
     match serde_json::to_string_pretty(report) {
         Ok(json) => println!("{json}"),
         Err(e) => eprintln!("[tokemon] Error serializing sessions: {e}"),
+    }
+}
+
+pub fn print_status_json(status: &StatusReport) {
+    match serde_json::to_string_pretty(status) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("[tokemon] Error serializing status: {e}"),
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,7 +5,7 @@ pub mod table;
 
 pub use csv::{print_csv_breakdown, print_csv_compact, print_csv_sessions};
 pub use helpers::{format_cost, format_tokens_short};
-pub use json::{print_json, print_sessions_json};
+pub use json::{print_json, print_sessions_json, print_status_json};
 pub use table::{
     print_budget, print_discover, print_sessions_table, print_statusline, print_table,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -196,6 +196,37 @@ pub struct Report {
     pub total_tokens: u64,
 }
 
+/// Stable machine-readable status document for lightweight clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusReport {
+    pub schema_version: u32,
+    pub generated_at: DateTime<Utc>,
+    pub state: String,
+    pub scope: StatusScope,
+    pub providers: Vec<String>,
+    pub summaries: Vec<PeriodSummary>,
+    pub total_cost: f64,
+    pub total_tokens: u64,
+    pub total_requests: u64,
+    pub capabilities: StatusCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusScope {
+    pub frequency: String,
+    pub since: Option<NaiveDate>,
+    pub until: Option<NaiveDate>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusCapabilities {
+    pub cost: bool,
+    pub date_filters: bool,
+    pub provider_filters: bool,
+    pub periodic_summaries: bool,
+    pub session_view: bool,
+}
+
 /// Summary for a single coding session
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionSummary {
@@ -385,5 +416,43 @@ mod tests {
         assert_eq!(GroupBy::Model.label(), "model");
         assert_eq!(GroupBy::ModelClient.label(), "model+client");
         assert_eq!(GroupBy::Client.label(), "client");
+    }
+
+    #[test]
+    fn status_report_serializes_versioned_empty_state() {
+        let generated_at = Utc::now();
+        let status = StatusReport {
+            schema_version: 1,
+            generated_at,
+            state: "empty".to_string(),
+            scope: StatusScope {
+                frequency: "daily".to_string(),
+                since: None,
+                until: None,
+            },
+            providers: Vec::new(),
+            summaries: Vec::new(),
+            total_cost: 0.0,
+            total_tokens: 0,
+            total_requests: 0,
+            capabilities: StatusCapabilities {
+                cost: true,
+                date_filters: true,
+                provider_filters: true,
+                periodic_summaries: true,
+                session_view: true,
+            },
+        };
+
+        let value = serde_json::to_value(&status).expect("status should serialize");
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["state"], "empty");
+        assert_eq!(value["scope"]["frequency"], "daily");
+        assert_eq!(value["providers"], serde_json::json!([]));
+        assert_eq!(value["total_tokens"], 0);
+        assert_eq!(value["total_requests"], 0);
+        assert!(value["capabilities"]["periodic_summaries"]
+            .as_bool()
+            .unwrap_or(false));
     }
 }


### PR DESCRIPTION
## Summary
- add a versioned `status --json` document backed by the existing usage pipeline
- expose scope, providers, totals, periodic summaries, capabilities, and explicit empty state
- document the command and add serialization coverage

## Verification
- cargo fmt -- --check
- cargo test
- cargo clippy -- -W clippy::pedantic -A clippy::module_name_repetitions
- cargo build --release
- offline status JSON smoke test

Fixes #23